### PR TITLE
Refresh contributor documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,22 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `PungentRoots/`: SwiftUI app sources (entry in `PungentRootsApp.swift`, UI in `ContentView.swift`, feature folders like `Detection/`, `Services/`, `Views/` house the auto-capture controller, rule engine, OCR pipeline, and settings UI).
-- `PungentRootsTests/`: unit targets built with Apple’s new `Testing` framework—use it for rule engine, normalization, and service fixtures.
+- `PungentRoots/`: SwiftUI app sources.
+  - `PungentRootsApp.swift`: bootstraps the dictionary and shares services through `AppEnvironment`.
+  - `Camera/`: `LiveCaptureController` wraps `AVCaptureSession` + Vision OCR auto-capture, including zoom/readiness heuristics and capture throttling.
+  - `OCR/`: `OCRConfiguration` presets Vision request tuning; `DocumentCameraView` hosts VisionKit-based still capture.
+  - `Services/`: `AppEnvironment` wires `DetectionEngine`, `TextAcquisitionService`, and shared normalizer instances.
+  - `Detection/`: dictionary models (`DetectDictionary`), rule-based `DetectionEngine`, and `DetectionScoring` constants.
+  - `Utilities/`: normalization and regex helpers used across detection/OCR layers.
+  - `Models/`: SwiftData-compatible `Scan` record plus supporting enums and match structs.
+  - `Views/`: SwiftUI presentation (camera overlays, detection cards, settings, reporting) that consume environment services.
+  - `Resources/`: bundled assets such as `pungent_roots_dictionary.json` (keep versioned and alphabetized by locale group).
+- `PungentRootsTests/`: unit targets built with Apple’s new `Testing` framework—cover normalization, detection scoring, and service fixtures.
 - `PungentRootsUITests/`: UI automation and accessibility assertions.
-- `Assets.xcassets/`: app imagery, color sets, and future brand tokens; keep generated thumbnails out of source control.
 - `Scripts/`: automation helpers (e.g. `run-tests.sh` wraps `xcodebuild` and simulator shutdown for CI/local consistency).
 
 ## Build, Test, and Development Commands
-- `xed .` or `open PungentRoots.xcodeproj`: open the project in Xcode.
+- `xed .` or `open PungentRoots.xcodeproj`: open the project in Xcode 15+ (iOS 17+ SDK recommended).
 - `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro" build`: deterministic CI build.
 - `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro"`: run all targets, including `Testing` suites.
 - `Scripts/run-tests.sh`: preferred wrapper for local/CI runs; executes the command above and shuts down simulators afterward to conserve resources.
@@ -19,18 +27,26 @@
 - Types use UpperCamelCase (`ScanResultView`); methods/properties use lowerCamelCase (`recognizeText`).
 - Organize files by feature and mirror that layout under test targets.
 - Use `///` doc comments for non-obvious logic; avoid inline chatter.
+- Camera/OCR work occurs off the main actor—hop back to `DispatchQueue.main`/`@MainActor` when mutating observable state.
 
 ## Testing Guidelines
 - Default to the `Testing` framework (`import Testing`) with structured `@Test` functions; mark UI-bound cases `@MainActor`.
-- Store deterministic fixtures alongside tests (`DetectionFixtures.swift`, normalization/OCR helpers). Keep them lightweight and language-specific.
+- Store deterministic fixtures alongside tests (dictionary snapshots, normalization samples, OCR mocks). Keep them lightweight and language-specific.
 - Name tests with behavior-focused phrases (`@Test("Onion powder triggers contains verdict")`).
-- Maintain ≥90% coverage on detection utilities and add regression tests whenever dictionaries or scoring rules change.
+- Maintain ≥90% coverage on detection utilities and add regression tests whenever dictionaries, scoring thresholds, or OCR heuristics change.
+- For camera/OCR changes, include at least one integration test (or documented manual runbook) that exercises `LiveCaptureController` readiness transitions.
+
+## Documentation & Process Notes
+- Update `README.md` when workflows or architecture entry points change; keep the developer summary concise but actionable.
+- Maintain `AGENTS.md`, `GEMINI.md`, and `CLAUDE.md` in sync with repository structure. Claude and Gemini guides must remain equivalently detailed, each calling out their agent-specific best practices (Claude code snippets, Gemini CLI responses).
+- The detection dictionary is versioned—bump the JSON `version` string and note the rationale in commit/PR descriptions when editing ingredients.
+- Record manual validation steps for camera/OCR tuning in `PLAN.md` when automation is impractical.
 
 ## Commit & Pull Request Guidelines
 - Write imperative, present-tense summaries (`Add detection engine service`) with optional scope tags (`[Detection]`); keep the first line ≤72 chars.
 - Reference issues or Notion tasks in the body, and list validation evidence (`xcodebuild test`, simulator screenshots) before requesting review.
 - PRs must include: purpose summary, targeted screens/devices, accessibility considerations, and any new assets/fixtures as separate commits when practical.
-- Before merging, confirm `AGENTS.md` and `PLAN.md` reflect structural or process updates.
+- Before merging, confirm `AGENTS.md`, `PLAN.md`, and agent guides reflect structural or process updates.
 
 ## Documentation Resources
 - Use the context7 tool to pull the latest Apple documentation—the Vision, AVFoundation, and SwiftUI APIs evolve quickly and recent changes may not be in cached references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE Guide
+
+## Quick Context
+- PungentRoots is a SwiftUI iOS app that scans ingredient labels with on-device Vision OCR and a rule-driven detection engine for allium terms.
+- The core flow runs `LiveCaptureController` → `TextAcquisitionService` → `DetectionEngine`, surfacing `DetectionResult` data to SwiftUI views under `Views/`.
+- Models in `Models/` keep normalized UTF-16 ranges aligned with the UI highlight logic and future persistence needs.
+
+## Key Files to Inspect First
+1. `PungentRoots/Camera/LiveCaptureController.swift` – camera session orchestration, readiness heuristics, throttling.
+2. `PungentRoots/OCR/OCRConfiguration.swift` & `Services/TextAcquisitionService.swift` – Vision request tuning and normalization pipeline.
+3. `PungentRoots/Detection/DetectionEngine.swift` & `Detection/DetectDictionary.swift` – rule passes, scoring constants, and dictionary loading.
+4. `PungentRoots/Views/` (especially `DetectionResultView.swift`) – how detection payloads render and trigger accessibility cues.
+5. `PungentRootsTests/` – baseline coverage patterns using Apple’s `Testing` framework.
+
+## Workflow Expectations
+- Trace data end-to-end (capture → normalization → detection → presentation) before suggesting changes; call out side effects between modules.
+- Pair every substantive code edit with matching tests or a documented manual validation plan when automation is infeasible.
+- Keep the detection dictionary versioned and alphabetized; highlight rationale for ingredient changes in commit/PR messages.
+
+## Response & Coding Style
+- Provide narrative reasoning followed by focused Swift code blocks in ```swift``` fences; prefer patch snippets when showing edits.
+- Emphasize concurrency notes (actors, queues) and enumerate accessibility implications of UI changes.
+- Recommend validation commands (e.g., `Scripts/run-tests.sh`, targeted `xcodebuild test`) at the end of summaries.
+
+## Quality & Safety Checks
+- Uphold 4-space indentation, `guard`-first early exits, and functions under ~80 lines; suggest extracting helpers into `Utilities/` when logic grows.
+- Flag any networking, logging of sensitive OCR text, or privacy regressions immediately—processing must stay on-device.
+- Ensure PR messaging aligns with repository guidelines and that agent docs stay synchronized (compare `GEMINI.md` for parity).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,28 @@
+# GEMINI Playbook
+
+## Quick Context
+- PungentRoots is a SwiftUI iOS app that performs on-device Vision OCR and dictionary-based detection to flag allium ingredients.
+- The capture-to-verdict pipeline flows through `LiveCaptureController`, `TextAcquisitionService`, and `DetectionEngine`, culminating in SwiftUI overlays within `Views/`.
+- Data models under `Models/` preserve normalized UTF-16 ranges that downstream highlights and persistence rely on.
+
+## Key Files to Inspect First
+1. `PungentRoots/Camera/LiveCaptureController.swift` – camera session coordination, readiness heuristics, throttling logic.
+2. `PungentRoots/OCR/OCRConfiguration.swift` & `Services/TextAcquisitionService.swift` – Vision request configuration and normalization stack.
+3. `PungentRoots/Detection/DetectionEngine.swift` & `Detection/DetectDictionary.swift` – rule passes, scoring constants, bundled dictionary loading.
+4. `PungentRoots/Views/` (notably `DetectionResultView.swift`) – renders verdict cards, highlights, and accessibility messaging.
+5. `PungentRootsTests/` – reference usage of Apple’s `Testing` framework for behavior-driven coverage.
+
+## Workflow Expectations
+- Map the full capture → normalization → detection → presentation journey before proposing edits; note cross-module effects explicitly.
+- Pair feature work with automated tests or spell out manual reproduction steps and simulator targets when automation is impractical.
+- Keep the detection dictionary alphabetized and versioned; document ingredient rationale inside commits/PRs.
+
+## Response & CLI Style
+- Deliver succinct bullet-point reasoning followed by shell-friendly command snippets in ```bash``` fences when sharing workflows or validation steps.
+- Surface exact commands for builds/tests (`Scripts/run-tests.sh`, `xcodebuild` invocations) and annotate expected outputs or follow-up actions.
+- Highlight concurrency considerations (actors, queues) and accessibility checks whenever UI flows are touched.
+
+## Quality & Safety Checks
+- Reinforce 4-space indentation, `guard`-first early exits, and <80-line functions; suggest extracting helpers into `Utilities/` when logic expands.
+- Reject proposals that introduce networking, cloud processing, or logging of sensitive OCR text—processing must remain on-device.
+- Mirror the guidance level found in `CLAUDE.md` so agent docs stay synchronized.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# PungentRoots
+
+## Developer Summary
+PungentRoots is a SwiftUI iOS app that screens ingredient labels for allium-containing terms entirely on-device. Live capture uses `AVCaptureSession` plus Vision OCR to stream text into a rule-based detection engine that scores risk levels and surfaces accessibility-friendly verdicts to the UI. The codebase is organized by feature (camera/OCR, detection, services, views) so each module can evolve independently while sharing normalization utilities.
+
+## Architecture at a Glance
+1. **App bootstrap** – `PungentRootsApp` loads the bundled dictionary and injects shared services through `AppEnvironment`.
+2. **Capture + OCR** – `LiveCaptureController` steers camera authorization, zoom heuristics, and `VNRecognizeTextRequest` scheduling; `TextAcquisitionService` and `OCRConfiguration` normalize text for detection.
+3. **Detection Engine** – `DetectionEngine` consults `DetectDictionary` to run exact, synonym, pattern, ambiguous, and fuzzy passes that yield `DetectionResult` aggregates.
+4. **Models & Persistence** – Types in `Models/` (`Scan`, `Match`, enums) mirror detection payloads and keep highlight ranges consistent for SwiftUI overlays.
+5. **Presentation** – SwiftUI views under `Views/` render camera overlays, result cards, settings, and reporting affordances while respecting environment services.
+
+## Local Development
+- Open `PungentRoots.xcodeproj` in Xcode 15+ (iOS 17+ SDK recommended) or run `xed .`.
+- Preferred build: `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro" build`.
+- Preferred full test pass: `Scripts/run-tests.sh` (wraps `xcodebuild test` and simulator shutdown for reproducibility).
+- Dictionary source lives at `PungentRoots/Resources/pungent_roots_dictionary.json`; keep entries sorted, localized groupings intact, and bump the embedded `version` field when editing.
+
+## Contribution Notes
+- Detection assumes normalized UTF-16 ranges—when adjusting tokenizers or matchers, preserve range math to keep highlights accurate.
+- Camera and OCR work run off the main actor; funnel UI mutations back through `DispatchQueue.main`/`@MainActor` to avoid state races.
+- When expanding verdicts or UI states, update `DetectionResultView` (and related overlays) plus add coverage under `PungentRootsTests/` or document manual validation for camera heuristics.


### PR DESCRIPTION
## Summary
- tighten the README developer summary and local workflow guidance
- update AGENTS instructions to keep agent guides in parity and document manual validation expectations
- align CLAUDE and GEMINI playbooks with matching detail while highlighting their code vs CLI response styles

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68de954830e8832f94eb774e9e17018c