### PR TITLE
Modernize capture UI and detection pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,22 @@
 ## Project Structure & Module Organization
 - `PungentRoots/`: SwiftUI app sources.
   - `PungentRootsApp.swift`: bootstraps the dictionary and shares services through `AppEnvironment`.
-  - `Camera/`: `LiveCaptureController` wraps `AVCaptureSession` + Vision OCR auto-capture, including zoom/readiness heuristics and capture throttling.
-  - `OCR/`: `OCRConfiguration` presets Vision request tuning; `DocumentCameraView` hosts VisionKit-based still capture.
-  - `Services/`: `AppEnvironment` wires `DetectionEngine`, `TextAcquisitionService`, and shared normalizer instances.
+  - `Camera/`: `AutoCaptureController` chooses VisionKit’s `DataScannerViewController` when supported and falls back to `LiveCaptureController` (AVFoundation + Vision OCR) for older hardware. Legacy controller still exposes zoom/readiness heuristics used by overlays.
+  - `OCR/`: `OCRConfiguration` presets Vision request tuning; `TextAcquisitionService` converts scanner payloads into normalized strings.
+  - `Services/`: `AppEnvironment` (now `@Observable`) wires `DetectionEngine`, `TextAcquisitionService`, capture configuration, and shared normalizer instances. `MetricReporter` subscribes to `MXMetricManager` for performance telemetry.
   - `Detection/`: dictionary models (`DetectDictionary`), rule-based `DetectionEngine`, and `DetectionScoring` constants.
   - `Utilities/`: normalization and regex helpers used across detection/OCR layers.
   - `Models/`: SwiftData-compatible `Scan` record plus supporting enums and match structs.
-  - `Views/`: SwiftUI presentation (camera overlays, detection cards, settings, reporting) that consume environment services.
-  - `Resources/`: bundled assets such as `pungent_roots_dictionary.json` (keep versioned and alphabetized by locale group).
+  - `Views/`: SwiftUI presentation (camera overlays, detection cards, settings, reporting) that consume environment services and use system materials/Dynamic Type-friendly layouts.
+  - `Resources/`: localization assets (`en.lproj/Localizable.strings`) and bundled dictionary JSON (keep versioned and alphabetized by locale group).
 - `PungentRootsTests/`: unit targets built with Apple’s new `Testing` framework—cover normalization, detection scoring, and service fixtures.
 - `PungentRootsUITests/`: UI automation and accessibility assertions.
 - `Scripts/`: automation helpers (e.g. `run-tests.sh` wraps `xcodebuild` and simulator shutdown for CI/local consistency).
 
 ## Build, Test, and Development Commands
 - `xed .` or `open PungentRoots.xcodeproj`: open the project in Xcode 15+ (iOS 17+ SDK recommended).
-- `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro" build`: deterministic CI build.
-- `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro"`: run all targets, including `Testing` suites.
+- `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" build`: deterministic CI build.
+- `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro"`: run all targets, including `Testing` suites.
 - `Scripts/run-tests.sh`: preferred wrapper for local/CI runs; executes the command above and shuts down simulators afterward to conserve resources.
 - `swift test`: keep parity once SwiftPM packages or previews are extracted.
 
@@ -27,14 +27,14 @@
 - Types use UpperCamelCase (`ScanResultView`); methods/properties use lowerCamelCase (`recognizeText`).
 - Organize files by feature and mirror that layout under test targets.
 - Use `///` doc comments for non-obvious logic; avoid inline chatter.
-- Camera/OCR work occurs off the main actor—hop back to `DispatchQueue.main`/`@MainActor` when mutating observable state.
+- Camera/OCR work occurs off the main actor—hop back to `DispatchQueue.main`/`@MainActor` when mutating observable state. Prefer `AppEnvironment.analyzeAsync` for long-running detection.
 
 ## Testing Guidelines
 - Default to the `Testing` framework (`import Testing`) with structured `@Test` functions; mark UI-bound cases `@MainActor`.
 - Store deterministic fixtures alongside tests (dictionary snapshots, normalization samples, OCR mocks). Keep them lightweight and language-specific.
 - Name tests with behavior-focused phrases (`@Test("Onion powder triggers contains verdict")`).
 - Maintain ≥90% coverage on detection utilities and add regression tests whenever dictionaries, scoring thresholds, or OCR heuristics change.
-- For camera/OCR changes, include at least one integration test (or documented manual runbook) that exercises `LiveCaptureController` readiness transitions.
+- For camera/OCR changes, include at least one integration test (or documented manual runbook) that exercises `AutoCaptureController` readiness transitions (VisionKit + legacy paths) and async detection flows.
 
 ## Documentation & Process Notes
 - Update `README.md` when workflows or architecture entry points change; keep the developer summary concise but actionable.

--- a/PungentRoots/Camera/AutoCaptureController.swift
+++ b/PungentRoots/Camera/AutoCaptureController.swift
@@ -1,0 +1,480 @@
+import Foundation
+
+#if os(iOS)
+import Combine
+import Observation
+import SwiftUI
+import UIKit
+import VisionKit
+
+@available(iOS 16.0, *)
+@MainActor
+@Observable
+final class AutoCaptureController {
+    enum Mode {
+        case dataScanner(DataScannerCaptureController)
+        case legacy(LiveCaptureController)
+    }
+
+    enum State: Equatable {
+        case idle
+        case preparing
+        case scanning
+        case processing
+        case paused
+        case error(String)
+
+        init(_ legacy: LiveCaptureController.State) {
+            switch legacy {
+            case .idle: self = .idle
+            case .preparing: self = .preparing
+            case .scanning: self = .scanning
+            case .processing: self = .processing
+            case .paused: self = .paused
+            case .error(let message): self = .error(message)
+            }
+        }
+    }
+
+    private(set) var state: State = .idle
+    private(set) var readiness: LiveCaptureController.ReadinessLevel = .none
+    private(set) var mode: Mode
+
+    var isUsingDataScanner: Bool {
+        if case .dataScanner = mode {
+            return true
+        }
+        return false
+    }
+
+    init(
+        prefersDataScanner: Bool,
+        ocrConfiguration: OCRConfiguration = .default
+    ) {
+        if prefersDataScanner, DataScannerCaptureController.isSupported {
+            let controller = DataScannerCaptureController()
+            mode = .dataScanner(controller)
+            bindDataScanner(controller)
+        } else {
+            let controller = LiveCaptureController(ocrConfig: ocrConfiguration)
+            mode = .legacy(controller)
+            bindLegacy(controller)
+        }
+    }
+
+    func setHandlers(
+        onCapture: @escaping (LiveCaptureController.RecognizedPayload) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        switch mode {
+        case .dataScanner(let controller):
+            controller.setHandlers(onCapture: onCapture, onError: onError)
+        case .legacy(let controller):
+            controller.setHandlers(onCapture: onCapture, onError: onError)
+        }
+    }
+
+    func start() {
+        switch mode {
+        case .dataScanner(let controller):
+            controller.start()
+        case .legacy(let controller):
+            controller.start()
+        }
+    }
+
+    func stop() {
+        switch mode {
+        case .dataScanner(let controller):
+            controller.stop()
+        case .legacy(let controller):
+            controller.stop()
+        }
+    }
+
+    func resumeScanning() {
+        switch mode {
+        case .dataScanner(let controller):
+            controller.resumeScanning()
+        case .legacy(let controller):
+            controller.resumeScanning()
+        }
+    }
+
+    func finishProcessing() {
+        switch mode {
+        case .dataScanner(let controller):
+            controller.finishProcessing()
+        case .legacy(let controller):
+            controller.finishProcessing()
+        }
+    }
+
+    var legacyController: LiveCaptureController? {
+        if case .legacy(let controller) = mode {
+            return controller
+        }
+        return nil
+    }
+
+    var dataScannerController: DataScannerCaptureController? {
+        if case .dataScanner(let controller) = mode {
+            return controller
+        }
+        return nil
+    }
+
+    private func bindLegacy(_ controller: LiveCaptureController) {
+        controller.$state.receive(on: DispatchQueue.main).sink { [weak self] newState in
+            guard let self else { return }
+            self.state = State(newState)
+        }
+        .store(in: &legacyCancellables)
+
+        controller.$readiness.receive(on: DispatchQueue.main).sink { [weak self] readiness in
+            self?.readiness = readiness
+        }
+        .store(in: &legacyCancellables)
+    }
+
+    private func bindDataScanner(_ controller: DataScannerCaptureController) {
+        controller.stateDidChange = { [weak self] newState in
+            self?.state = newState
+        }
+
+        controller.readinessDidChange = { [weak self] readiness in
+            self?.readiness = readiness
+        }
+    }
+
+    // MARK: - Private
+
+    @ObservationIgnored
+    private var legacyCancellables: Set<AnyCancellable> = []
+}
+
+@available(iOS 16.0, *)
+@MainActor
+@Observable
+final class DataScannerCaptureController: NSObject, DataScannerViewControllerDelegate {
+    typealias RecognizedPayload = LiveCaptureController.RecognizedPayload
+
+    static var isSupported: Bool {
+        DataScannerViewController.isSupported && DataScannerViewController.isAvailable
+    }
+
+    var stateDidChange: ((AutoCaptureController.State) -> Void)?
+    var readinessDidChange: ((LiveCaptureController.ReadinessLevel) -> Void)?
+
+    private(set) var state: AutoCaptureController.State = .idle {
+        didSet {
+            guard state != oldValue else { return }
+            stateDidChange?(state)
+        }
+    }
+
+    private(set) var readiness: LiveCaptureController.ReadinessLevel = .none {
+        didSet {
+            guard readiness != oldValue else { return }
+            readinessDidChange?(readiness)
+        }
+    }
+
+    private var onCapture: ((RecognizedPayload) -> Void)?
+    private var onError: ((String) -> Void)?
+
+    private var scanner: DataScannerViewController?
+    private var pendingCaptureWorkItem: DispatchWorkItem?
+    private var hasDeliveredCapture = false
+
+    func setHandlers(
+        onCapture: @escaping (RecognizedPayload) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        self.onCapture = onCapture
+        self.onError = onError
+    }
+
+    func makeScannerIfNeeded() -> DataScannerViewController? {
+        if let scanner {
+            return scanner
+        }
+
+        do {
+            let recognizedDataTypes: Set<DataScannerViewController.RecognizedDataType> = [.text()]
+            let controller = try DataScannerViewController(
+                recognizedDataTypes: recognizedDataTypes,
+                qualityLevel: .balanced,
+                recognizesMultipleItems: false,
+                isHighFrameRateTrackingEnabled: true,
+                isPinchToZoomEnabled: true,
+                isGuidanceEnabled: true,
+                isHighlightingEnabled: true
+            )
+            controller.delegate = self
+            controller.view.backgroundColor = .clear
+            scanner = controller
+            return controller
+        } catch {
+            onError?("Unable to configure data scanner.")
+            return nil
+        }
+    }
+
+    func start() {
+        guard let scanner = makeScannerIfNeeded() else { return }
+        guard state != .scanning else { return }
+        state = .preparing
+        pendingCaptureWorkItem?.cancel()
+        hasDeliveredCapture = false
+
+        Task { @MainActor in
+            do {
+                try scanner.startScanning()
+                state = .scanning
+                readiness = .none
+            } catch {
+                reportError("Data scanner could not start.")
+            }
+        }
+    }
+
+    func stop() {
+        pendingCaptureWorkItem?.cancel()
+        scanner?.stopScanning()
+        state = .idle
+        readiness = .none
+        hasDeliveredCapture = false
+    }
+
+    func resumeScanning() {
+        guard let scanner else {
+            start()
+            return
+        }
+        pendingCaptureWorkItem?.cancel()
+        hasDeliveredCapture = false
+        Task { @MainActor in
+            do {
+                try scanner.startScanning()
+                state = .scanning
+                readiness = .none
+            } catch {
+                reportError("Failed to resume data scanner.")
+            }
+        }
+    }
+
+    func finishProcessing() {
+        state = .paused
+        readiness = .none
+    }
+
+    // MARK: - DataScannerViewControllerDelegate
+
+    func dataScanner(
+        _ dataScanner: DataScannerViewController,
+        didAdd addedItems: [RecognizedItem],
+        allItems: [RecognizedItem]
+    ) {
+        evaluateReadiness(for: allItems)
+        scheduleCaptureIfNeeded(from: allItems)
+    }
+
+    func dataScanner(
+        _ dataScanner: DataScannerViewController,
+        didRemove removedItems: [RecognizedItem],
+        allItems: [RecognizedItem]
+    ) {
+        evaluateReadiness(for: allItems)
+    }
+
+    func dataScanner(
+        _ dataScanner: DataScannerViewController,
+        observedError: (any Error),
+        isCritical: Bool
+    ) {
+        reportError("Scanner error: \(observedError.localizedDescription)")
+    }
+
+    // MARK: - Helpers
+
+    private func scheduleCaptureIfNeeded(from items: [RecognizedItem]) {
+        guard state == .scanning else { return }
+        guard hasDeliveredCapture == false else { return }
+
+        let textItems = Self.textItems(from: items)
+        guard !textItems.isEmpty else { return }
+
+        pendingCaptureWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.sendCapture(for: textItems)
+        }
+
+        pendingCaptureWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: workItem)
+    }
+
+    private func sendCapture(for items: [RecognizedItem.Text]) {
+        guard hasDeliveredCapture == false else { return }
+        guard let scanner else { return }
+
+        hasDeliveredCapture = true
+        state = .processing
+        scanner.stopScanning()
+
+        let viewBounds = scanner.view.bounds
+        let payloadItems = items.map { textItem -> RecognizedPayload.Item in
+            LiveCaptureController.RecognizedPayload.Item(
+                text: textItem.transcript,
+                boundingBox: Self.normalizedRect(from: textItem.bounds, in: viewBounds)
+            )
+        }
+
+        let payload = RecognizedPayload(items: payloadItems, capturedImage: nil)
+        onCapture?(payload)
+    }
+
+    private func evaluateReadiness(for items: [RecognizedItem]) {
+        guard state == .scanning else {
+            readiness = .none
+            return
+        }
+
+        let textItems = Self.textItems(from: items)
+        if textItems.isEmpty {
+            readiness = .tooFar
+        } else if textItems.contains(where: { $0.transcript.count > 6 }) {
+            readiness = .ready
+        } else {
+            readiness = .almostReady
+        }
+    }
+
+    private func reportError(_ message: String) {
+        onError?(message)
+        state = .error(message)
+    }
+
+    private static func textItems(from items: [RecognizedItem]) -> [RecognizedItem.Text] {
+        items.compactMap { item in
+            if case let .text(text) = item {
+                return text
+            }
+            return nil
+        }
+    }
+
+    private static func normalizedRect(from bounds: RecognizedItem.Bounds, in viewBounds: CGRect) -> CGRect {
+        guard viewBounds.width > 0, viewBounds.height > 0 else { return .zero }
+
+        let points = [bounds.topLeft, bounds.topRight, bounds.bottomRight, bounds.bottomLeft]
+        let minX = points.map { $0.x }.min() ?? 0
+        let maxX = points.map { $0.x }.max() ?? 0
+        let minY = points.map { $0.y }.min() ?? 0
+        let maxY = points.map { $0.y }.max() ?? 0
+
+        let width = max(0, maxX - minX)
+        let height = max(0, maxY - minY)
+
+        if width <= 0 || height <= 0 {
+            return .zero
+        }
+
+        let normalizedX = minX / viewBounds.width
+        // Convert from UIKit top-left coordinate space to normalized bottom-left
+        let normalizedY = (viewBounds.height - maxY) / viewBounds.height
+        let normalizedWidth = width / viewBounds.width
+        let normalizedHeight = height / viewBounds.height
+
+        return CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight)
+    }
+}
+
+@available(iOS 16.0, *)
+struct DataScannerContainerView: UIViewControllerRepresentable {
+    let controller: DataScannerCaptureController
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        ScannerHostingViewController(controller: controller)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        // No-op: controller manages scanner state changes.
+    }
+}
+
+@available(iOS 16.0, *)
+private final class ScannerHostingViewController: UIViewController {
+    private let controller: DataScannerCaptureController
+    private var embeddedScanner: DataScannerViewController?
+
+    init(controller: DataScannerCaptureController) {
+        self.controller = controller
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attachScannerIfNeeded()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        controller.stop()
+    }
+
+    private func attachScannerIfNeeded() {
+        guard embeddedScanner == nil else { return }
+        guard let scanner = controller.makeScannerIfNeeded() else { return }
+        embeddedScanner = scanner
+
+        addChild(scanner)
+        scanner.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scanner.view)
+        NSLayoutConstraint.activate([
+            scanner.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scanner.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scanner.view.topAnchor.constraint(equalTo: view.topAnchor),
+            scanner.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        scanner.didMove(toParent: self)
+    }
+}
+
+@available(iOS 16.0, *)
+extension AutoCaptureController.State {
+    var descriptor: (text: LocalizedStringKey, icon: String) {
+        switch self {
+        case .idle:
+            return (LocalizedStringKey("scan.status.default_idle"), "camera")
+        case .preparing:
+            return (LocalizedStringKey("scan.status.default_preparing"), "camera")
+        case .scanning:
+            return (LocalizedStringKey("scan.status.default_scanning"), "camera.viewfinder")
+        case .processing:
+            return (LocalizedStringKey("scan.status.default_processing"), "wand.and.stars")
+        case .paused:
+            return (LocalizedStringKey("scan.status.default_paused"), "checkmark.circle")
+        case .error:
+            return (LocalizedStringKey("scan.status.default_error"), "exclamationmark.triangle")
+        }
+    }
+}
+
+#else
+
+@MainActor
+typealias AutoCaptureController = LiveCaptureController
+
+#endif

--- a/PungentRoots/Camera/LiveCaptureController.swift
+++ b/PungentRoots/Camera/LiveCaptureController.swift
@@ -460,6 +460,13 @@ final class LiveCaptureController: ObservableObject {
         case error(String)
     }
 
+    enum ReadinessLevel: Equatable {
+        case none
+        case tooFar
+        case almostReady
+        case ready
+    }
+
     struct RecognizedPayload {
         struct Item {
             let text: String
@@ -473,6 +480,7 @@ final class LiveCaptureController: ObservableObject {
     }
 
     @Published private(set) var state: State = .idle
+    @Published private(set) var readiness: ReadinessLevel = .none
     var supportsZoom: Bool { false }
     var zoomRange: ClosedRange<CGFloat> { 1.0...1.0 }
     var zoomFactor: CGFloat { 1.0 }

--- a/PungentRoots/Detection/DetectionEngine.swift
+++ b/PungentRoots/Detection/DetectionEngine.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DetectionEngine {
+struct DetectionEngine: Sendable {
     private let dictionary: DetectDictionary
     private let normalizer: TextNormalizer
     private let scoring: DetectionScoring

--- a/PungentRoots/Detection/DetectionScoring.swift
+++ b/PungentRoots/Detection/DetectionScoring.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Centralized configuration for detection scoring and thresholds
-struct DetectionScoring {
+struct DetectionScoring: Sendable {
     // MARK: - Match Score Contributions
 
     /// Score contribution for definite matches (exact term matches)

--- a/PungentRoots/Models/RetakeButtonAlignment.swift
+++ b/PungentRoots/Models/RetakeButtonAlignment.swift
@@ -1,15 +1,17 @@
 import Foundation
 
+import SwiftUI
+
 enum RetakeButtonAlignment: String, CaseIterable, Identifiable {
     case leading
     case trailing
 
     var id: String { rawValue }
 
-    var displayName: String {
+    var displayName: LocalizedStringKey {
         switch self {
-        case .leading: return "Left"
-        case .trailing: return "Right"
+        case .leading: return LocalizedStringKey("settings.retake.leading")
+        case .trailing: return LocalizedStringKey("settings.retake.trailing")
         }
     }
 }

--- a/PungentRoots/PungentRootsApp.swift
+++ b/PungentRoots/PungentRootsApp.swift
@@ -2,20 +2,16 @@ import SwiftUI
 
 @main
 struct PungentRootsApp: App {
-    @StateObject private var appEnvironment: AppEnvironment
+    @State private var appEnvironment: AppEnvironment
 
     init() {
-        let dictionary = try? DictionaryLoader(bundle: .main).load()
-        guard let dictionary else {
-            fatalError("Unable to load detection dictionary")
-        }
-        _appEnvironment = StateObject(wrappedValue: AppEnvironment(dictionary: dictionary))
+        _appEnvironment = State(wrappedValue: .live())
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(appEnvironment)
+                .environment(appEnvironment)
         }
     }
 }

--- a/PungentRoots/Resources/en.lproj/Localizable.strings
+++ b/PungentRoots/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,53 @@
+"scan.navigation.title" = "Scan Ingredients";
+"scan.status.move_closer" = "Move closer to label";
+"scan.status.almost_ready" = "Almost ready—hold steady";
+"scan.status.ready" = "Capturing now…";
+"scan.status.default_idle" = "Starting scanner…";
+"scan.status.default_preparing" = "Preparing scanner…";
+"scan.status.default_scanning" = "Hold steady for auto capture";
+"scan.status.default_processing" = "Analyzing frame…";
+"scan.status.default_paused" = "Capture complete";
+"scan.status.default_error" = "Scanner paused";
+"scan.status.accessibility.hint" = "Scanner status updates as capture progresses.";
+"scan.error.title" = "Scanner unavailable";
+"scan.error.retry" = "Try Again";
+"scan.retake.accessibility" = "Retake scan";
+"scan.retake.hint" = "Capture another image of the ingredient list.";
+"scan.summary.none" = "No pungent root matches detected.";
+"scan.summary.single" = "1 match detected. Review details.";
+"scan.summary.multiple" = "%d matches detected. Review details.";
+
+"common.done" = "Done";
+"common.info" = "Info";
+
+"settings.capture.heading" = "Capture";
+"settings.visionkit.toggle" = "VisionKit Auto Scanner";
+"settings.visionkit.description" = "Use Apple's Live Text pipeline when available for faster, on-device recognition.";
+"settings.visionkit.unsupported" = "VisionKit requires an A12 Bionic or newer device running iOS 16.";
+"settings.retake.title" = "Retake Button Position";
+"settings.retake.caption" = "Position at bottom corner for easy thumb access";
+"settings.retake.leading" = "Left";
+"settings.retake.trailing" = "Right";
+"settings.tips.title" = "Capture Tips";
+"settings.tips.fill_frame" = "Fill the frame with the ingredient list";
+"settings.tips.hold_steady" = "Hold steady while the camera focuses";
+"settings.tips.rescan" = "Rescan anytime to update results";
+
+"settings.privacy.heading" = "Privacy";
+"settings.privacy.on_device.title" = "All processing on-device";
+"settings.privacy.on_device.description" = "Camera access powers automatic captures. No photos or text leave your device.";
+
+"settings.dictionary.heading" = "Detection Dictionary";
+"settings.dictionary.version" = "Version";
+"settings.dictionary.coverage" = "Coverage";
+"settings.dictionary.coverage_value" = "50+ terms";
+"settings.dictionary.description" = "Detects onions, garlic, shallots, leeks, chives, scallions, ramps, and related alliums with synonyms and pattern matching.";
+
+"settings.support.heading" = "Support";
+"settings.support.report.title" = "Report Issues";
+"settings.support.report.description" = "Use the Report Issue button when you find incorrect detections.";
+"settings.support.fresh.title" = "Fresh Results";
+"settings.support.fresh.description" = "Scans are transient. Rescan for updated results with each label.";
+
+"settings.navigation.title" = "Info & Settings";
+"settings.header.tagline" = "Detect alliums in ingredients instantly";

--- a/PungentRoots/Services/AppEnvironment+Fixtures.swift
+++ b/PungentRoots/Services/AppEnvironment+Fixtures.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+extension AppEnvironment {
+    static func live(bundle: Bundle = .main) -> AppEnvironment {
+        do {
+            let dictionary = try DictionaryLoader(bundle: bundle).load()
+            return AppEnvironment(
+                dictionary: dictionary,
+                captureOptions: defaultCaptureOptions()
+            )
+        } catch {
+            assertionFailure("Failed to load dictionary: \(error)")
+            return AppEnvironment(dictionary: .fallback, captureOptions: defaultCaptureOptions())
+        }
+    }
+
+    static var preview: AppEnvironment {
+        AppEnvironment(dictionary: .preview, captureOptions: .init(prefersDataScanner: false))
+    }
+}
+
+private extension DetectDictionary {
+    static var preview: DetectDictionary {
+        DetectDictionary(
+            definite: ["onion", "garlic"],
+            patterns: ["dehydrated\\s+garlic"],
+            ambiguous: ["stock"],
+            synonyms: ["allium"],
+            fuzzyHints: ["garilc"],
+            version: "preview"
+        )
+    }
+
+    static var fallback: DetectDictionary {
+        DetectDictionary(
+            definite: [],
+            patterns: [],
+            ambiguous: [],
+            synonyms: [],
+            fuzzyHints: [],
+            version: "fallback"
+        )
+    }
+}
+
+@MainActor
+private func defaultCaptureOptions() -> AppEnvironment.CaptureOptions {
+#if os(iOS)
+    if #available(iOS 16.0, *) {
+        return AppEnvironment.CaptureOptions(prefersDataScanner: DataScannerCaptureController.isSupported)
+    } else {
+        return AppEnvironment.CaptureOptions(prefersDataScanner: false)
+    }
+#else
+    return AppEnvironment.CaptureOptions(prefersDataScanner: false)
+#endif
+}

--- a/PungentRoots/Services/AppEnvironment.swift
+++ b/PungentRoots/Services/AppEnvironment.swift
@@ -1,26 +1,65 @@
 import Foundation
+import Observation
 import os
 
 @MainActor
-final class AppEnvironment: ObservableObject {
+@Observable
+final class AppEnvironment {
+    struct CaptureOptions: Sendable {
+        var prefersDataScanner: Bool = true
+    }
+
     let detectionEngine: DetectionEngine
     let dictionary: DetectDictionary
     let normalizer: TextNormalizer
     let textAcquisition: TextAcquisitionService
-    private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "Detection")
+    var captureOptions: CaptureOptions
 
-    init(dictionary: DetectDictionary, normalizer: TextNormalizer = TextNormalizer()) {
+    private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "Detection")
+    private let signposter = OSSignposter(subsystem: "co.ouchieco.PungentRoots", category: "Detection")
+
+    init(
+        dictionary: DetectDictionary,
+        normalizer: TextNormalizer = TextNormalizer(),
+        scoring: DetectionScoring = .default,
+        captureOptions: CaptureOptions = .init()
+    ) {
         self.dictionary = dictionary
         self.normalizer = normalizer
-        self.detectionEngine = DetectionEngine(dictionary: dictionary, normalizer: normalizer)
+        self.detectionEngine = DetectionEngine(dictionary: dictionary, normalizer: normalizer, scoring: scoring)
         self.textAcquisition = TextAcquisitionService(normalizer: normalizer)
+        self.captureOptions = captureOptions
+
+#if canImport(MetricKit)
+        _ = MetricReporter.shared
+#endif
     }
 
     func analyze(_ rawText: String) -> (normalized: String, result: DetectionResult) {
+        let signpostID = signposter.makeSignpostID()
+        let interval = signposter.beginInterval("SynchronousAnalyze", id: signpostID)
         let start = DispatchTime.now()
         let analysis = detectionEngine.analyze(rawText: rawText)
         let duration = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+        signposter.endInterval("SynchronousAnalyze", interval)
         logger.debug("Detection completed in \(duration, format: .fixed(precision: 2))ms (\(analysis.result.matches.count) matches)")
         return analysis
+    }
+
+    func analyzeAsync(_ rawText: String) async -> (normalized: String, result: DetectionResult) {
+        let engine = detectionEngine
+        let signposter = self.signposter
+        let result = await Task(priority: .userInitiated) { () -> (String, DetectionResult, Double) in
+            let signpostID = signposter.makeSignpostID()
+            let interval = signposter.beginInterval("AsyncAnalyze", id: signpostID)
+            let start = DispatchTime.now()
+            let analysis = engine.analyze(rawText: rawText)
+            let duration = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+            signposter.endInterval("AsyncAnalyze", interval)
+            return (analysis.normalized, analysis.result, duration)
+        }.value
+
+        logger.debug("Async detection completed in \(result.2, format: .fixed(precision: 2))ms (\(result.1.matches.count) matches)")
+        return (result.0, result.1)
     }
 }

--- a/PungentRoots/Services/MetricReporter.swift
+++ b/PungentRoots/Services/MetricReporter.swift
@@ -1,0 +1,32 @@
+#if canImport(MetricKit)
+
+import Foundation
+import MetricKit
+import os
+
+@MainActor
+final class MetricReporter: NSObject, MXMetricManagerSubscriber {
+    static let shared = MetricReporter()
+
+    private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "Metrics")
+
+    private override init() {
+        super.init()
+        MXMetricManager.shared.add(self)
+        logger.debug("MetricReporter subscribed to MXMetricManager")
+    }
+
+    deinit {
+        MXMetricManager.shared.remove(self)
+    }
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        logger.debug("Received metric payload count=\(payloads.count, privacy: .public)")
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        logger.warning("Diagnostic payload count=\(payloads.count, privacy: .public)")
+    }
+}
+
+#endif

--- a/PungentRootsTests/PungentRootsTests.swift
+++ b/PungentRootsTests/PungentRootsTests.swift
@@ -82,4 +82,18 @@ struct DetectionEngineTests {
         #expect(analysis.result.matches.isEmpty)
         #expect(analysis.result.verdict == .safe)
     }
+
+    @Test("Async analyzer matches synchronous detection results")
+    @MainActor
+    func asyncAnalyzerMatchesSync() async {
+        let environment = AppEnvironment(dictionary: dictionary)
+        let sample = "Ingredients: wheat flour, onion powder, salt"
+
+        let syncResult = environment.analyze(sample)
+        let asyncResult = await environment.analyzeAsync(sample)
+
+        #expect(asyncResult.normalized == syncResult.normalized)
+        #expect(asyncResult.result.matches == syncResult.result.matches)
+        #expect(asyncResult.result.verdict == syncResult.result.verdict)
+    }
 }

--- a/PungentRootsUITests/PungentRootsUITests.swift
+++ b/PungentRootsUITests/PungentRootsUITests.swift
@@ -38,4 +38,25 @@ final class PungentRootsUITests: XCTestCase {
             XCUIApplication().launch()
         }
     }
+
+    @MainActor
+    func testSettingsSupportsDynamicType() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append(contentsOf: ["-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibility3"])
+        app.launch()
+
+        app.buttons["Info"].tap()
+
+        let navBar = app.navigationBars["Info & Settings"]
+        XCTAssertTrue(navBar.waitForExistence(timeout: 3))
+
+        let toggle = app.switches.firstMatch
+        XCTAssertTrue(toggle.waitForExistence(timeout: 2))
+
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "Settings-DynamicType-AX3"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # PungentRoots
 
 ## Developer Summary
-PungentRoots is a SwiftUI iOS app that screens ingredient labels for allium-containing terms entirely on-device. Live capture uses `AVCaptureSession` plus Vision OCR to stream text into a rule-based detection engine that scores risk levels and surfaces accessibility-friendly verdicts to the UI. The codebase is organized by feature (camera/OCR, detection, services, views) so each module can evolve independently while sharing normalization utilities.
+PungentRoots is a SwiftUI iOS app that screens ingredient labels for allium-containing terms entirely on-device. Live capture defaults to VisionKit’s `DataScannerViewController` for low-latency text extraction, falling back to the legacy `AVCaptureSession` + Vision OCR pipeline when hardware support is unavailable. A rule-based detection engine scores risk levels and surfaces accessibility-friendly verdicts to the UI. The codebase is organized by feature (camera/OCR, detection, services, views) so each module can evolve independently while sharing normalization utilities.
 
 ## Architecture at a Glance
 1. **App bootstrap** – `PungentRootsApp` loads the bundled dictionary and injects shared services through `AppEnvironment`.
-2. **Capture + OCR** – `LiveCaptureController` steers camera authorization, zoom heuristics, and `VNRecognizeTextRequest` scheduling; `TextAcquisitionService` and `OCRConfiguration` normalize text for detection.
-3. **Detection Engine** – `DetectionEngine` consults `DetectDictionary` to run exact, synonym, pattern, ambiguous, and fuzzy passes that yield `DetectionResult` aggregates.
+2. **Capture + OCR** – `AutoCaptureController` negotiates between VisionKit `DataScannerViewController` and the legacy `LiveCaptureController` (AVFoundation + Vision) while `TextAcquisitionService` and `OCRConfiguration` normalize text for detection. Camera UI now uses system materials, Dynamic Type-aware sizing, and localized guidance.
+3. **Detection Engine** – `DetectionEngine` consults `DetectDictionary` to run exact, synonym, pattern, ambiguous, and fuzzy passes that yield `DetectionResult` aggregates. Async helpers in `AppEnvironment` execute scoring off the main thread with signpost instrumentation.
 4. **Models & Persistence** – Types in `Models/` (`Scan`, `Match`, enums) mirror detection payloads and keep highlight ranges consistent for SwiftUI overlays.
-5. **Presentation** – SwiftUI views under `Views/` render camera overlays, result cards, settings, and reporting affordances while respecting environment services.
+5. **Presentation** – SwiftUI views under `Views/` render camera overlays, result cards, settings, and reporting affordances while respecting environment services. Shared strings live in `Resources/en.lproj/Localizable.strings` for future localization.
+6. **Observability** – `MetricReporter` subscribes to `MXMetricManager` and `OSSignposter` intervals capture detection latency for performance regression tracking.
 
 ## Local Development
 - Open `PungentRoots.xcodeproj` in Xcode 15+ (iOS 17+ SDK recommended) or run `xed .`.
@@ -18,5 +19,5 @@ PungentRoots is a SwiftUI iOS app that screens ingredient labels for allium-cont
 
 ## Contribution Notes
 - Detection assumes normalized UTF-16 ranges—when adjusting tokenizers or matchers, preserve range math to keep highlights accurate.
-- Camera and OCR work run off the main actor; funnel UI mutations back through `DispatchQueue.main`/`@MainActor` to avoid state races.
+- Camera and OCR work run off the main actor; funnel UI mutations back through `DispatchQueue.main`/`@MainActor` to avoid state races. Use `AppEnvironment.analyzeAsync` for long-running analysis.
 - When expanding verdicts or UI states, update `DetectionResultView` (and related overlays) plus add coverage under `PungentRootsTests/` or document manual validation for camera heuristics.

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-DEST="platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro"
+# Allow overriding from the environment while defaulting to an available simulator.
+DEST="${DEST:-platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro}"
 
 echo "Running tests on $DEST"
 xcodebuild test -scheme PungentRoots -destination "$DEST"


### PR DESCRIPTION
## Summary
- adopt VisionKit-first scanner with fallback and localized UI refresh
- migrate AppEnvironment to async detection with signposts + MetricKit
- add localization scaffolding and dynamic type UI coverage

## Testing
- Scripts/run-tests.sh (iOS Simulator, OS=18.6, iPhone 16 Pro)