### PR TITLE
[codex] Refresh packaging-first scan flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,110 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## Canonical Agent Guide
+- `AGENTS.md` is the source of truth for GPT-5.4/Codex work in this repo.
+- `CLAUDE.md` and `GEMINI.md` are thin compatibility wrappers. Update them only when agent-specific behavior changes.
+- When architecture, workflow, or validation guidance changes, update `AGENTS.md` first, then adjust wrappers if needed.
+
+## Project Structure & Module Ownership
 - `PungentRoots/`: SwiftUI app sources.
-  - `PungentRootsApp.swift`: bootstraps the dictionary and shares services through `AppEnvironment`.
-  - `Camera/`: `AutoCaptureController` chooses VisionKit’s `DataScannerViewController` when supported and falls back to `LiveCaptureController` (AVFoundation + Vision OCR) for older hardware. Legacy controller still exposes zoom/readiness heuristics used by overlays.
-  - `OCR/`: `OCRConfiguration` presets Vision request tuning; `TextAcquisitionService` converts scanner payloads into normalized strings.
-  - `Services/`: `AppEnvironment` (now `@Observable`) wires `DetectionEngine`, `TextAcquisitionService`, capture configuration, and shared normalizer instances. `MetricReporter` subscribes to `MXMetricManager` for performance telemetry.
-  - `Detection/`: dictionary models (`DetectDictionary`), rule-based `DetectionEngine`, and `DetectionScoring` constants.
-  - `Utilities/`: normalization and regex helpers used across detection/OCR layers.
-  - `Models/`: SwiftData-compatible `Scan` record plus supporting enums and match structs.
-  - `Views/`: SwiftUI presentation (camera overlays, detection cards, settings, guidance) that consume environment services and use system materials/Dynamic Type-friendly layouts.
-  - `Resources/`: localization assets (`en.lproj/Localizable.strings`) and bundled dictionary JSON (keep versioned and alphabetized by locale group).
-- `PungentRootsTests/`: unit targets built with Apple’s new `Testing` framework—cover normalization, detection scoring, and service fixtures.
-- `PungentRootsUITests/`: UI automation and accessibility assertions.
-- `Scripts/`: automation helpers (e.g. `run-tests.sh` wraps `xcodebuild` and simulator shutdown for CI/local consistency).
+  - `PungentRootsApp.swift`: boots the live `AppEnvironment` and injects it into the root scene.
+  - `ContentView.swift`: thin navigation shell; owns `@State private var flowModel = ScanFlowModel()`.
+  - `Camera/`:
+    - `CaptureTypes.swift`: shared `CapturePayload`, `CaptureState`, and `CaptureReadiness` used across capture and UI layers.
+    - `AutoCaptureController.swift`: orchestration layer that selects VisionKit `DataScannerViewController` when available and falls back to the legacy AVFoundation/Vision path.
+    - `LiveCaptureController.swift`: legacy capture implementation with readiness and zoom heuristics. Keep this behind shared capture-domain types.
+  - `OCR/`: OCR configuration and document camera helpers.
+  - `Services/`:
+    - `AppEnvironment.swift`: shared dependency container. It owns services and returns typed `ScanAnalysis` values from analysis entrypoints.
+    - `ScanFlowModel.swift`: `@MainActor @Observable` screen-level orchestration for capture, analysis, cancellation, UI-test preview state, and rescan flow.
+    - `TextAcquisitionService.swift`: converts capture payloads into normalized text inputs for detection.
+    - `MetricReporter.swift`: MetricKit subscriber for performance telemetry.
+  - `Detection/`: bundled dictionary loading, rule-based matching, and scoring thresholds.
+  - `Models/`:
+    - `Scan.swift`: core detection result, match, verdict, and persistence-facing model types.
+    - `ScanAnalysis.swift`: shared analysis payload passed between services, views, previews, and tests.
+  - `Utilities/`: normalization and regex helpers.
+  - `Views/`:
+    - `ScanCameraModuleView.swift`: capture surface, status badge, and capture error presentation.
+    - `ScanResultSectionView.swift`: processing/result container.
+    - `DetectionResultView.swift`: verdict card, transcript disclosure, and rescan affordance.
+    - `AdaptiveGlass.swift`: iOS 26 Liquid Glass helpers with pre-iOS 26 material fallbacks.
+    - Supporting overlays, empty states, and shared badges.
+  - `Resources/`: localization strings and the bundled detection dictionary.
+- `PungentRootsTests/`: unit coverage using Apple’s `Testing` framework.
+- `PungentRootsUITests/`: scenario-based UI coverage, including settings, transcript disclosure, rescan flow, and accessibility-size checks.
+- `Scripts/run-tests.sh`: canonical local/CI test wrapper.
 
-## Build, Test, and Development Commands
-- `xed .` or `open PungentRoots.xcodeproj`: open the project in Xcode 15+ (iOS 17+ SDK recommended).
-- `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" build`: deterministic CI build.
-- `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro"`: run all targets, including `Testing` suites.
-- `Scripts/run-tests.sh`: preferred wrapper for local/CI runs; executes the command above and shuts down simulators afterward to conserve resources.
-- `swift test`: keep parity once SwiftPM packages or previews are extracted.
+## Non-Negotiables
+- Minimum deployment target stays `iOS 18.5`.
+- iOS 26 APIs are additive only. Guard all Liquid Glass and newer UI behavior with availability checks and ship functional fallbacks below iOS 26.
+- Keep all OCR and detection processing on-device. Do not add network calls without explicit approval.
+- Do not leak `LiveCaptureController`-specific types into SwiftUI. Shared UI state must flow through `CapturePayload`, `CaptureState`, and `CaptureReadiness`.
+- `ContentView` stays thin. Put screen orchestration in `ScanFlowModel`, not in view bodies.
+- `AppEnvironment` is a service container and analysis entrypoint, not a screen view model.
+- Use `ScanAnalysis` instead of ad hoc tuples for analysis results.
+- Cancel stale analysis work before starting rescans or stopping the screen.
 
-## Coding Style & Naming Conventions
-- Swift source: 4-space indentation, avoid trailing whitespace, prefer `guard` for early exits, keep functions <80 lines.
-- Types use UpperCamelCase (`ScanResultView`); methods/properties use lowerCamelCase (`recognizeText`).
-- Organize files by feature and mirror that layout under test targets.
-- Use `///` doc comments for non-obvious logic; avoid inline chatter.
-- Camera/OCR work occurs off the main actor—hop back to `DispatchQueue.main`/`@MainActor` when mutating observable state. Prefer `AppEnvironment.analyzeAsync` for long-running detection.
+## Build, Test, and Validation Commands
+- `xed .` or `open PungentRoots.xcodeproj`: open the project in Xcode.
+- `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" build`: deterministic simulator build.
+- `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro"`: full test run.
+- `Scripts/run-tests.sh`: preferred wrapper for local and CI validation.
+
+## iOS Workflow Expectations
+- Inspect the full scan path before editing behavior: `ContentView` -> `ScanFlowModel` -> `AutoCaptureController`/`CaptureTypes` -> `TextAcquisitionService` -> `AppEnvironment.analyzeAsync` -> result views.
+- Prefer small dedicated SwiftUI views with stable trees and explicit state boundaries.
+- Keep async work and side effects out of view bodies. Start and cancel work from `ScanFlowModel`.
+- When updating capture behavior, validate both VisionKit-supported and forced-legacy paths.
+- When touching glass styling, keep it focused on high-value chrome: badges, compact controls, settings header, and primary actions. Avoid placing dense transcript content or the live camera preview inside heavy glass treatments.
+
+## Preferred Tools & References
+- Use the Apple docs MCP/context7 tooling for current SwiftUI, VisionKit, AVFoundation, Observation, and Liquid Glass guidance.
+- Codex users should prefer the Build iOS Apps skills when relevant:
+  - `build-ios-apps:swiftui-view-refactor`
+  - `build-ios-apps:swiftui-ui-patterns`
+  - `build-ios-apps:swiftui-liquid-glass`
+  - `build-ios-apps:swiftui-performance-audit`
+  - `build-ios-apps:ios-debugger-agent`
+- Capture citation links in PR notes when behavior depends on recent Apple API guidance.
+
+## Coding Style
+- Swift source uses 4-space indentation, no trailing whitespace, and `guard` for early exits.
+- Keep functions under roughly 80 lines. Extract helpers or subviews when bodies grow.
+- Types use UpperCamelCase; methods and properties use lowerCamelCase.
+- Prefer `@MainActor` or `MainActor.run` when mutating observable UI state from async work.
+- Add `///` comments only where logic is not obvious from the code.
 
 ## Testing Guidelines
-- Default to the `Testing` framework (`import Testing`) with structured `@Test` functions; mark UI-bound cases `@MainActor`.
-- Store deterministic fixtures alongside tests (dictionary snapshots, normalization samples, OCR mocks). Keep them lightweight and language-specific.
-- Name tests with behavior-focused phrases (`@Test("Onion powder triggers contains verdict")`).
-- Maintain ≥90% coverage on detection utilities and add regression tests whenever dictionaries, scoring thresholds, or OCR heuristics change.
-- For camera/OCR changes, include at least one integration test (or documented manual runbook) that exercises `AutoCaptureController` readiness transitions (VisionKit + legacy paths) and async detection flows.
+- Default to the `Testing` framework with behavior-focused `@Test` names.
+- Add or update tests when changing:
+  - detection scoring or dictionary behavior
+  - normalization or OCR heuristics
+  - `ScanFlowModel` state transitions
+  - capture-state mapping or overlay severity behavior
+- Maintain scenario-oriented UI tests for settings presentation, transcript disclosure, rescan behavior, and accessibility sizing.
+- Keep UI-test launch hooks working:
+  - `--ui-test-disable-capture`
+  - `--ui-test-preview-result`
+- If a camera/OCR change cannot be covered automatically, document the manual runbook in `PLAN.md`.
 
-## Documentation & Process Notes
-- Update `README.md` when workflows or architecture entry points change; keep the developer summary concise but actionable.
-- Maintain `AGENTS.md`, `GEMINI.md`, and `CLAUDE.md` in sync with repository structure. Claude and Gemini guides must remain equivalently detailed, each calling out their agent-specific best practices (Claude code snippets, Gemini CLI responses).
-- The detection dictionary is versioned—bump the JSON `version` string and note the rationale in commit/PR descriptions when editing ingredients.
-- Record manual validation steps for camera/OCR tuning in `PLAN.md` when automation is impractical.
+## Documentation & Process
+- Update `README.md` when architecture entry points, developer workflow, or platform strategy changes.
+- Update `PLAN.md` when manual validation steps or device coverage expectations change.
+- Bump the detection dictionary `version` string and record the rationale in commit/PR text whenever the JSON changes.
+- Before merging structural work, confirm `AGENTS.md`, `README.md`, and `PLAN.md` match the implementation.
 
 ## Commit & Pull Request Guidelines
-- Write imperative, present-tense summaries (`Add detection engine service`) with optional scope tags (`[Detection]`); keep the first line ≤72 chars.
-- Reference issues or Notion tasks in the body, and list validation evidence (`xcodebuild test`, simulator screenshots) before requesting review.
-- PRs must include: purpose summary, targeted screens/devices, accessibility considerations, and any new assets/fixtures as separate commits when practical.
-- Before merging, confirm `AGENTS.md`, `PLAN.md`, and agent guides reflect structural or process updates.
+- Use imperative, present-tense commit summaries with optional scopes, e.g. `[Camera] Unify capture state types`.
+- Keep the first commit line at or below 72 characters.
+- PRs should include:
+  - purpose summary
+  - validation evidence (`Scripts/run-tests.sh`, targeted simulator checks, screenshots if relevant)
+  - targeted devices or simulator configurations
+  - accessibility notes
+  - dictionary version rationale when applicable
 
-## Documentation Resources
-- Use the context7 tool to pull the latest Apple documentation—the Vision, AVFoundation, and SwiftUI APIs evolve quickly and recent changes may not be in cached references.
-- Capture citation links when quoting API guidance so reviewers can verify assumptions.
-
-## Security & Privacy Notes
-- Processing stays on-device; do not introduce network calls without explicit approval.
-- Strip sensitive text from debug logs and dispose of intermediate scan images after persistence completes.
+## Security & Privacy
+- Strip sensitive ingredient text from debug logs.
+- Dispose of intermediate scan images after they are no longer needed.
+- Keep privacy copy accurate: OCR and detection stay on-device, with no network dependency.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,8 @@
 # CLAUDE Guide
 
-## Quick Context
-- PungentRoots is a SwiftUI iOS app that scans ingredient labels with on-device Vision OCR and a rule-driven detection engine for allium terms.
-- The core flow runs `LiveCaptureController` → `TextAcquisitionService` → `DetectionEngine`, surfacing `DetectionResult` data to SwiftUI views under `Views/`.
-- Models in `Models/` keep normalized UTF-16 ranges aligned with the UI highlight logic and future persistence needs.
+Use `AGENTS.md` as the canonical repo guide.
 
-## Key Files to Inspect First
-1. `PungentRoots/Camera/LiveCaptureController.swift` – camera session orchestration, readiness heuristics, throttling.
-2. `PungentRoots/OCR/OCRConfiguration.swift` & `Services/TextAcquisitionService.swift` – Vision request tuning and normalization pipeline.
-3. `PungentRoots/Detection/DetectionEngine.swift` & `Detection/DetectDictionary.swift` – rule passes, scoring constants, and dictionary loading.
-4. `PungentRoots/Views/` (especially `DetectionResultView.swift`) – how detection payloads render and trigger accessibility cues.
-5. `PungentRootsTests/` – baseline coverage patterns using Apple’s `Testing` framework.
-
-## Workflow Expectations
-- Trace data end-to-end (capture → normalization → detection → presentation) before suggesting changes; call out side effects between modules.
-- Pair every substantive code edit with matching tests or a documented manual validation plan when automation is infeasible.
-- Keep the detection dictionary versioned and alphabetized; highlight rationale for ingredient changes in commit/PR messages.
-
-## Response & Coding Style
-- Provide narrative reasoning followed by focused Swift code blocks in ```swift``` fences; prefer patch snippets when showing edits.
-- Emphasize concurrency notes (actors, queues) and enumerate accessibility implications of UI changes.
-- Recommend validation commands (e.g., `Scripts/run-tests.sh`, targeted `xcodebuild test`) at the end of summaries.
-
-## Quality & Safety Checks
-- Uphold 4-space indentation, `guard`-first early exits, and functions under ~80 lines; suggest extracting helpers into `Utilities/` when logic grows.
-- Flag any networking, logging of sensitive OCR text, or privacy regressions immediately—processing must stay on-device.
-- Ensure PR messaging aligns with repository guidelines and that agent docs stay synchronized (compare `GEMINI.md` for parity).
+## Claude-Specific Notes
+- Prefer short narrative reasoning followed by focused `swift` code blocks when showing examples.
+- Call out concurrency and accessibility implications explicitly when reviewing UI or capture changes.
+- When summarizing work, include the validation command you actually ran, usually `Scripts/run-tests.sh`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,28 +1,8 @@
 # GEMINI Playbook
 
-## Quick Context
-- PungentRoots is a SwiftUI iOS app that performs on-device Vision OCR and dictionary-based detection to flag allium ingredients.
-- The capture-to-verdict pipeline flows through `LiveCaptureController`, `TextAcquisitionService`, and `DetectionEngine`, culminating in SwiftUI overlays within `Views/`.
-- Data models under `Models/` preserve normalized UTF-16 ranges that downstream highlights and persistence rely on.
+Use `AGENTS.md` as the canonical repo guide.
 
-## Key Files to Inspect First
-1. `PungentRoots/Camera/LiveCaptureController.swift` – camera session coordination, readiness heuristics, throttling logic.
-2. `PungentRoots/OCR/OCRConfiguration.swift` & `Services/TextAcquisitionService.swift` – Vision request configuration and normalization stack.
-3. `PungentRoots/Detection/DetectionEngine.swift` & `Detection/DetectDictionary.swift` – rule passes, scoring constants, bundled dictionary loading.
-4. `PungentRoots/Views/` (notably `DetectionResultView.swift`) – renders verdict cards, highlights, and accessibility messaging.
-5. `PungentRootsTests/` – reference usage of Apple’s `Testing` framework for behavior-driven coverage.
-
-## Workflow Expectations
-- Map the full capture → normalization → detection → presentation journey before proposing edits; note cross-module effects explicitly.
-- Pair feature work with automated tests or spell out manual reproduction steps and simulator targets when automation is impractical.
-- Keep the detection dictionary alphabetized and versioned; document ingredient rationale inside commits/PRs.
-
-## Response & CLI Style
-- Deliver succinct bullet-point reasoning followed by shell-friendly command snippets in ```bash``` fences when sharing workflows or validation steps.
-- Surface exact commands for builds/tests (`Scripts/run-tests.sh`, `xcodebuild` invocations) and annotate expected outputs or follow-up actions.
-- Highlight concurrency considerations (actors, queues) and accessibility checks whenever UI flows are touched.
-
-## Quality & Safety Checks
-- Reinforce 4-space indentation, `guard`-first early exits, and <80-line functions; suggest extracting helpers into `Utilities/` when logic expands.
-- Reject proposals that introduce networking, cloud processing, or logging of sensitive OCR text—processing must remain on-device.
-- Mirror the guidance level found in `CLAUDE.md` so agent docs stay synchronized.
+## Gemini-Specific Notes
+- Prefer concise, shell-friendly summaries and concrete command snippets when describing workflow or validation.
+- Surface exact build and test commands rather than paraphrasing them.
+- Keep architecture references aligned with the current `ScanFlowModel` -> shared capture types -> `ScanAnalysis` flow.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,133 +1,43 @@
-# PungentRoots v0.1 Implementation Plan
+# PungentRoots Validation Plan
 
-## 1. Product Goals
-- Deliver a trustworthy on-device tool that flags pungent-root ingredients (garlic, onion, shallot, leek, chive, scallion) in photos or pasted text within the target performance budgets.
-- Provide transparent explanations, risk scoring, and a history that builds user confidence while preserving privacy.
-- Lay foundations for extensibility (additional languages, custom rules, share extensions) without compromising the MVP timeline.
+## Current Architecture Checkpoints
+- `ContentView` is a thin shell that owns `ScanFlowModel`.
+- `ScanFlowModel` handles capture orchestration, async analysis, cancellation, rescan, and UI-test preview hooks.
+- `AppEnvironment` returns typed `ScanAnalysis` values.
+- Shared capture-domain types live in `PungentRoots/Camera/CaptureTypes.swift`.
+- Liquid Glass is applied selectively through `PungentRoots/Views/AdaptiveGlass.swift` and gated behind `iOS 26` availability checks.
 
-## 2. Guiding Principles & Apple Best Practices
-- Keep all processing on-device and isolate state using SwiftUI environment injection so views stay declarative and testable.[^swiftui-state]
-- Keep scan data ephemeral; rely on in-memory state and detection services rather than persisted records.[^swiftui-state]
-- Respect Apple’s Human Interface Guidelines by pairing color with clear iconography and typography, delivering accessible feedback across light/dark modes.[^hig-color]
-- Prepare Vision and VisionKit requests up front, tune them for accuracy versus speed, and scope work to regions of interest to stay within latency targets.[^vision-ocr][^visionkit]
-- Tokenize text with NaturalLanguage to reduce custom parsing logic and improve resilience to edge cases like Unicode punctuation.[^nltagger]
+## Automated Baseline
+- Run `Scripts/run-tests.sh` before and after substantive changes.
+- Keep unit coverage in `PungentRootsTests/` for analysis typing, flow-model transitions, overlay severity mapping, and detection behavior.
+- Keep scenario UI coverage in `PungentRootsUITests/` for:
+  - settings presentation
+  - transcript disclosure
+  - rescan returning to the capture state
+  - accessibility-size rendering
 
-## 3. MVP Scope Check
-- **Input:** Auto-capture defaults to VisionKit’s `DataScannerViewController` with a fallback `AVCaptureSession` pipeline for unsupported devices, plus a single rescan affordance for manual retries.
-- **Detection:** Normalize text, run deterministic matching (exact/synonym/pattern/fuzzy), and maintain internal scoring to inform guidance while surfacing match lists only.
-- **Output:** Inline match list with red/yellow severity, optional transcript toggle, and caméra tips encouraging fresh rescans (no persistent history).
-- **Persistence:** Keep captures ephemeral; explore opt-in history later if user demand returns.
+## Manual Validation Matrix
+- **Data Scanner path on supported hardware**
+  - Environment: iPhone simulator or device with `DataScannerViewController` support and the Data Scanner preference enabled.
+  - Steps: Launch the app, present a clear ingredient label, wait for capture, verify the status badge transitions through scanning/processing, then inspect the verdict card.
+  - Expected: Capture happens without showing the legacy fallback UI, OCR completes, verdict and highlights appear, and rescan resumes live scanning.
+- **Forced legacy path**
+  - Environment: Disable the Data Scanner setting or run on unsupported hardware.
+  - Steps: Launch the app, confirm the legacy capture path starts, scan an ingredient label, then rescan.
+  - Expected: Legacy readiness guidance appears, capture completes, result rendering matches the Data Scanner path, and rescan returns to the live preview.
+- **Camera permission denied or unavailable**
+  - Environment: Fresh simulator/device with camera permission denied, or an environment without camera availability.
+  - Steps: Launch the app and attempt to enter the scanning flow.
+  - Expected: The app surfaces a clear error state, does not crash, and remains navigable so the user can recover after changing permissions.
+- **iOS 26 Liquid Glass presentation**
+  - Environment: iOS 26 simulator or device.
+  - Steps: Inspect the settings header, status badge cluster, and primary result action.
+  - Expected: Glass treatments appear only on compact chrome, remain legible over backgrounds, and do not reduce transcript readability or preview clarity.
+- **Pre-iOS 26 fallback presentation**
+  - Environment: iOS 18.5 or 18.6 simulator.
+  - Steps: Repeat the same UI checks used for the iOS 26 pass.
+  - Expected: Material-based cards and buttons render correctly, layout stays stable, and no iOS 26-only API usage leaks into runtime.
 
-## 4. Architecture Overview
-1. **Input Layer**
-   - Route capture through `AutoCaptureController`, which prefers VisionKit’s `DataScannerViewController` and gracefully falls back to the legacy `LiveCaptureController` (AVFoundation + Vision) for unsupported hardware.
-   - Provide pinch/slider zoom, macro-focused configuration, and optional rescan control once results are shown.
-2. **OCR & Normalization Service**
-   - `TextAcquisitionService` orchestrates OCR tasks, returns normalized text with source metadata, and strips hyphen breaks, bullet characters, and problematic whitespace.
-3. **Detection Engine**
-   - Stateless service that consumes normalized text plus bundled dictionary JSON, emits matches with ranges and rationale, and scores risk per the weighting table.
-4. **Persistence Layer**
-   - Auto-capture controller manages camera state on a background queue while results stay on the main actor for UI updates.
-5. **Presentation Layer**
-   - SwiftUI navigation stack: Home (actions + history) → Capture/Paste flows → Result detail. Derived view models expose immutable state to views, with mutation isolated to services.
-
-## 5. Text Capture and OCR
-- Prefer VisionKit’s Data Scanner for live text detection; configure the scanner to highlight guidance, limit captures to a single ingredient block, and surface readiness feedback in the UI.
-- When Data Scanner isn’t available, configure a reusable `VNRecognizeTextRequest` with `.accurate` recognition and language correction, falling back to `.fast` for degraded images.[^vision-ocr]
-- Populate `recognitionLanguages` with `Locale.Language("en-US")` initially and expose a setting stub for future locales; rely on `supportedRecognitionLanguages` to validate availability.[^vision-ocr]
-- Run OCR on a background task; return results via `MainActor` isolation to satisfy Vision threading requirements and update UI state safely.
-
-## 6. Text Normalization & Tokenization
-- Normalize using Unicode NFKC, lowercase, collapse whitespace, rejoin hyphenated breaks, and strip punctuation that splits tokens unexpectedly.
-- Tokenize using `NLTagger(tagSchemes: [.tokenType])` with `.word` units and `.omitWhitespace` so the detection engine operates on consistent tokens regardless of input formatting.[^nltagger]
-- Maintain UTF-16 ranges for matches to stay compatible with SwiftUI attributed strings.
-
-## 7. Detection Engine
-- Load the bundled dictionary JSON into a cached `DetectDictionary` struct at launch; watch for decode failures and surface a non-blocking alert path.
-- Exact & synonym passes use regex with word boundaries; patterns handle suffixes like powder/salt/extract; ambiguous list triggers caution-tier matches; fuzzy pass applies Levenshtein distance thresholds for short vs. long tokens.
-- Accumulate scores by severity, cap ambiguous contributions, and derive verdict tiers (`safe` <0.3, `needsReview` <0.8, `contains` ≥0.8). Persist match notes for UI explanations.
-- Structure the engine for eventual replacements (e.g., Aho–Corasick) without changing the public API.
-
-## 8. UI Modernization Roadmap (Plan C)
-- **Audit & Baseline**
-  - Capture current camera module, result card, and settings layouts in light/dark with Dynamic Type XXL.
-  - Document spacing, typography, and accessibility gaps; track findings for follow-up.
-- **Visual Refresh**
-  - Replace custom gradients with `Material`/`GlassBackgroundStyle` and semantic system colors.
-  - Adopt `ViewThatFits`/adaptive stacks to accommodate compact vs. regular size classes.
-  - Update toolbar/navigation to large-title patterns with contextual trailing actions.
-- **Accessibility & Localization**
-  - Add descriptive accessibility labels, hints, and traits to overlays and status badges.
-  - Localize newly surfaced scanner guidance strings and regenerate `Localizable.strings`.
-  - Extend UI tests to cover Dynamic Type, VoiceOver focus, and refreshed snapshots.
-- **Validation**
-  - Smoke-test on simulator/device, verifying haptics and animations meet HIG guidance.
-  - Update README/AGENTS with refreshed UI descriptions and screenshots.
-
-## 9. Detection & Services Modernization (Plan D)
-- **Async Pipeline**
-  - Convert detection entrypoints to async using `Task` and cooperative cancellation between camera and detection layers.
-  - Maintain sync wrappers for backward compatibility while migrating tests.
-- **Instrumentation**
-  - Add `os.Logger` signposts for acquisition, normalization, and detection stages.
-  - Integrate `MetricKit` to capture latency and thermal metrics; surface dashboards for regression tracking.
-- **Text Processing Enhancements**
-  - Prototype `NaturalLanguage` tokenization; benchmark accuracy/performance against the regex pipeline.
-  - Externalize fuzzy thresholds to configuration for easier experimentation.
-- **Testing & QA**
-  - Expand `Testing` suites with async scenarios and additional fixtures.
-  - Document manual QA steps for detection latency/accuracy across sample labels.
-  - Enhance Scripts/run-tests.sh with optional async performance checks.
-
-## 8. Data Model & Persistence
-- Implement the provided `Scan` model with `@Model`, apply `@Attribute(.unique)` to `id`, and preserve user verdict overrides by marking key fields as `.preserveValueOnDeletion` when appropriate.[^swiftdata-model]
-- Store embedded `Match` structs in the `Scan` record to simplify fetches; include derived properties (e.g., `defaultVerdict`) in view models to keep models lean.
-- Inject `ModelContext` via `.modelContainer(for:)` at `App` root to share across scenes and ensure one source of truth for SwiftUI views.[^swiftui-state]
-- Provide lightweight migrations for dictionary evolve cases by versioning JSON and storing the version with each scan for analytics.
-
-## 9. SwiftUI Experience
-- Compose screens with `NavigationStack` + `NavigationSplitView` on iPad/Mac for history browsing, keeping detail view states synchronized with `@State` and `List` selection patterns recommended by SwiftUI docs.[^swiftui-state]
-- Drive view state with observable view models annotated using `@Observable` (or `@StateObject` where indirection is needed) to keep mutation controlled and preview-friendly.
-- Annotate highlights using attributed strings, ensuring VoiceOver exposes match context via `accessibilityAttributedLabel` and not color alone.[^hig-color]
-- Provide toggles and verdict chips that adapt to Dynamic Type and remain legible in high contrast settings.
-
-## 10. Accessibility, Feedback, and Trust
-- Announce verdict changes via `accessibilityAnnouncement` and pair them with subtle haptics (e.g., `.warning`) so feedback is multimodal.
-- Include copy clarifying that “Needs Review” items may mask alliums; reference ambiguous match notes directly from the detection engine.
-- Respect `Reduce Motion` by gating animations and provide secondary indicators (icons, text) wherever color coding is used.[^hig-color]
-
-## 11. Testing & Quality Gates
-- Unit-test normalization, detection scoring, and fuzzy matching with curated fixtures (20 contains, 20 ambiguous, 20 safe) to guarantee recall ≥0.98 for definite terms and precision ≥0.9 for `.contains` verdict.
-- Write integration tests covering OCR + detection using sample images; assert normalized strings include expected tokens with at most one edit distance variance.
-- Add SwiftUI snapshot or accessibility tests for the result screen to ensure highlight readability under Dynamic Type and dark mode.
-- Run async OCR tests on a background queue to surface threading regressions early.
-
-## 12. Privacy, Permissions, and Failure Modes
-- Present camera and photo-library permission copy emphasizing on-device processing and zero network use.
-- Gracefully degrade: if OCR fails, offer manual text entry with guidance; if detection finds only ambiguous terms, prompt the user to review and override verdict.
-- Cache scans locally only with explicit user opt-in for saving; expose a quick “Clear History” action that issues a batch delete on the main actor.
-
-## 13. Delivery Timeline (10 Working Days + Buffer)
-1. **Day 1–2:** Auto-capture controller scaffolding, camera authorization flow, detection integration, and loading/error states.
-2. **Day 3–4:** Zoom/macro tuning, alignment guides, and device tests across lighting scenarios.
-3. **Day 5:** Result card refinements, transcript toggle, color tokens, and motion cues (respecting Reduce Motion).
-4. **Day 6:** Accessibility pass (contrast, Dynamic Type, VoiceOver announcements) and logging instrumentation.
-5. **Day 7:** Error state copy, resiliency for capture failures, and guidance updates.
-6. **Day 8–9:** Unit + integration tests, sample image fixtures, automation hooks (CI script skeleton).
-7. **Day 10:** Polish, documentation, App Store asset placeholders, prepare TestFlight build.
-8. **Days 11–14 (buffer):** Stabilization, localization groundwork (dictionary versioning), release checklist.
-
-## 14. Stretch Roadmap (Post-v0.1)
-- Household rule overrides with shareable JSON exports (respecting on-device storage).
-- Share extension for Safari/Photos text scanning using the same detection engine.
-- Barcode lookup with optional consent-based network requests.
-- Additional language packs (ES/FR/IT) once dictionary translation pipeline is ready.
-- Active rectangle detection and optional CreateML-backed classifier to complement deterministic rules.
-
-## References
-[^swiftui-state]: Managing shared state with SwiftUI environment and property wrappers. <https://github.com/zhangyu1818/swiftui.md/blob/main/swiftui-model%20data-managing%20model%20data%20in%20your%20app.md#_snippet_10>
-[^swiftdata-model]: SwiftData model design and attribute configuration guidance. <https://developer.apple.com/documentation/technologyoverviews/structured-data-models>
-[^vision-ocr]: Configuring `VNRecognizeTextRequest` for accuracy, language correction, and performance. <https://developer.apple.com/documentation/Vision/locating-and-displaying-recognized-text>
-[^visionkit]: VisionKit overview and document camera guidance. <https://developer.apple.com/documentation/VisionKit>
-[^nltagger]: Tokenization with `NLTagger` using `.tokenType` for word units. <https://developer.apple.com/documentation/coreml/finding-answers-to-questions-in-a-text-document>
-[^hig-color]: Apple Human Interface Guidelines on color usage and accessibility pairing. <https://developer.apple.com/design/human-interface-guidelines/color>
+## Notes
+- If automation cannot cover a capture or OCR regression, add the reproduction steps here in the same format.
+- Update this file whenever device coverage, permission handling, or platform-specific fallback expectations change.

--- a/PungentRoots.xcodeproj/project.pbxproj
+++ b/PungentRoots.xcodeproj/project.pbxproj
@@ -400,8 +400,8 @@
 				DEVELOPMENT_TEAM = BD36Y7488S;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-					INFOPLIST_KEY_CFBundleDisplayName = "Pungent Roots";
-					INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pungent Roots";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				INFOPLIST_KEY_NSCameraUsageDescription = "PungentRoots needs camera access to scan ingredient labels.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -435,8 +435,8 @@
 				DEVELOPMENT_TEAM = BD36Y7488S;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-					INFOPLIST_KEY_CFBundleDisplayName = "Pungent Roots";
-					INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pungent Roots";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.food-and-drink";
 				INFOPLIST_KEY_NSCameraUsageDescription = "PungentRoots needs camera access to scan ingredient labels.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/PungentRoots/Camera/AutoCaptureController.swift
+++ b/PungentRoots/Camera/AutoCaptureController.swift
@@ -16,28 +16,8 @@ final class AutoCaptureController {
         case legacy(LiveCaptureController)
     }
 
-    enum State: Equatable {
-        case idle
-        case preparing
-        case scanning
-        case processing
-        case paused
-        case error(String)
-
-        init(_ legacy: LiveCaptureController.State) {
-            switch legacy {
-            case .idle: self = .idle
-            case .preparing: self = .preparing
-            case .scanning: self = .scanning
-            case .processing: self = .processing
-            case .paused: self = .paused
-            case .error(let message): self = .error(message)
-            }
-        }
-    }
-
-    private(set) var state: State = .idle
-    private(set) var readiness: LiveCaptureController.ReadinessLevel = .none
+    private(set) var state: CaptureState = .idle
+    private(set) var readiness: CaptureReadiness = .none
     private(set) var mode: Mode
 
     var isUsingDataScanner: Bool {
@@ -63,7 +43,7 @@ final class AutoCaptureController {
     }
 
     func setHandlers(
-        onCapture: @escaping (LiveCaptureController.RecognizedPayload) -> Void,
+        onCapture: @escaping (CapturePayload) -> Void,
         onError: @escaping (String) -> Void
     ) {
         switch mode {
@@ -127,7 +107,7 @@ final class AutoCaptureController {
     private func bindLegacy(_ controller: LiveCaptureController) {
         controller.$state.receive(on: DispatchQueue.main).sink { [weak self] newState in
             guard let self else { return }
-            self.state = State(newState)
+            self.state = newState
         }
         .store(in: &legacyCancellables)
 
@@ -157,23 +137,23 @@ final class AutoCaptureController {
 @MainActor
 @Observable
 final class DataScannerCaptureController: NSObject, DataScannerViewControllerDelegate {
-    typealias RecognizedPayload = LiveCaptureController.RecognizedPayload
+    typealias RecognizedPayload = CapturePayload
 
     static var isSupported: Bool {
         DataScannerViewController.isSupported && DataScannerViewController.isAvailable
     }
 
-    var stateDidChange: ((AutoCaptureController.State) -> Void)?
-    var readinessDidChange: ((LiveCaptureController.ReadinessLevel) -> Void)?
+    var stateDidChange: ((CaptureState) -> Void)?
+    var readinessDidChange: ((CaptureReadiness) -> Void)?
 
-    private(set) var state: AutoCaptureController.State = .idle {
+    private(set) var state: CaptureState = .idle {
         didSet {
             guard state != oldValue else { return }
             stateDidChange?(state)
         }
     }
 
-    private(set) var readiness: LiveCaptureController.ReadinessLevel = .none {
+    private(set) var readiness: CaptureReadiness = .none {
         didSet {
             guard readiness != oldValue else { return }
             readinessDidChange?(readiness)
@@ -327,7 +307,7 @@ final class DataScannerCaptureController: NSObject, DataScannerViewControllerDel
 
         let viewBounds = scanner.view.bounds
         let payloadItems = items.map { textItem -> RecognizedPayload.Item in
-            LiveCaptureController.RecognizedPayload.Item(
+            RecognizedPayload.Item(
                 text: textItem.transcript,
                 boundingBox: Self.normalizedRect(from: textItem.bounds, in: viewBounds)
             )
@@ -453,7 +433,7 @@ private final class ScannerHostingViewController: UIViewController {
 }
 
 @available(iOS 16.0, *)
-extension AutoCaptureController.State {
+extension CaptureState {
     var descriptor: (text: LocalizedStringKey, icon: String) {
         switch self {
         case .idle:

--- a/PungentRoots/Camera/CaptureTypes.swift
+++ b/PungentRoots/Camera/CaptureTypes.swift
@@ -1,0 +1,38 @@
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+
+enum CaptureState: Equatable, Sendable {
+    case idle
+    case preparing
+    case scanning
+    case processing
+    case paused
+    case error(String)
+}
+
+enum CaptureReadiness: Equatable, Sendable {
+    case none
+    case tooFar
+    case almostReady
+    case ready
+}
+
+struct CapturePayload {
+    struct Item: Hashable, Sendable {
+        let text: String
+        let boundingBox: CGRect
+    }
+
+    let items: [Item]
+#if os(iOS)
+    let capturedImage: UIImage?
+#else
+    let capturedImage: Never?
+#endif
+
+    var strings: [String] {
+        items.map(\.text)
+    }
+}

--- a/PungentRoots/Camera/LabelCaptureController.swift
+++ b/PungentRoots/Camera/LabelCaptureController.swift
@@ -1,0 +1,472 @@
+import Foundation
+import Observation
+import SwiftUI
+#if os(iOS)
+@preconcurrency import AVFoundation
+import Vision
+
+@MainActor
+@Observable
+final class LabelCaptureController: NSObject {
+    private(set) var state: CaptureState = .idle
+    private(set) var readiness: CaptureReadiness = .none
+
+    @ObservationIgnored
+    nonisolated(unsafe) fileprivate let session = AVCaptureSession()
+
+    @ObservationIgnored
+    private let sessionQueue = DispatchQueue(label: "co.ouchieco.PungentRoots.labelCapture.session", qos: .userInitiated)
+    @ObservationIgnored
+    private let analysisQueue = DispatchQueue(label: "co.ouchieco.PungentRoots.labelCapture.analysis", qos: .userInitiated)
+    @ObservationIgnored
+    nonisolated(unsafe) private let videoOutput = AVCaptureVideoDataOutput()
+    @ObservationIgnored
+    nonisolated(unsafe) private let photoOutput = AVCapturePhotoOutput()
+    @ObservationIgnored
+    private let ocrConfiguration: OCRConfiguration
+
+    @ObservationIgnored
+    nonisolated(unsafe) private var activeDevice: AVCaptureDevice?
+    @ObservationIgnored
+    nonisolated(unsafe) private var isConfigured = false
+    @ObservationIgnored
+    nonisolated(unsafe) private var isConfiguringSession = false
+    @ObservationIgnored
+    nonisolated(unsafe) private var authorizationInFlight = false
+    @ObservationIgnored
+    nonisolated(unsafe) private var readinessPaused = false
+    @ObservationIgnored
+    nonisolated(unsafe) private var frameThrottle: CFTimeInterval = CACurrentMediaTime()
+    @ObservationIgnored
+    nonisolated(unsafe) private var photoContinuation: CheckedContinuation<Data, Error>?
+    @ObservationIgnored
+    nonisolated(unsafe) private var isObservingSessionNotifications = false
+
+    @ObservationIgnored
+    private lazy var readinessRequest: VNRecognizeTextRequest = {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .fast
+        request.usesLanguageCorrection = false
+        request.minimumTextHeight = max(0.01, ocrConfiguration.minimumTextHeight * 0.8)
+        request.recognitionLanguages = ocrConfiguration.recognitionLanguages
+        if #available(iOS 16.0, *) {
+            request.revision = VNRecognizeTextRequestRevision3
+        }
+        return request
+    }()
+
+    init(ocrConfiguration: OCRConfiguration = .default) {
+        self.ocrConfiguration = ocrConfiguration
+        super.init()
+    }
+
+    func start() {
+        configureIfNeeded()
+    }
+
+    func stop() {
+        readinessPaused = true
+        unregisterForNotifications()
+        sessionQueue.async {
+            if self.session.isRunning {
+                self.session.stopRunning()
+            }
+        }
+        state = .idle
+        readiness = .none
+    }
+
+    func resumeScanning() {
+        readinessPaused = false
+        if isConfigured == false {
+            configureIfNeeded()
+            return
+        }
+
+        sessionQueue.async {
+            self.startSessionIfNeeded()
+        }
+    }
+
+    func capturePhotoData() async throws -> Data {
+        guard isConfigured else {
+            throw CaptureError.cameraUnavailable
+        }
+        guard photoContinuation == nil else {
+            throw CaptureError.captureInProgress
+        }
+
+        readinessPaused = true
+        state = .processing
+
+        return try await withCheckedThrowingContinuation { continuation in
+            photoContinuation = continuation
+            sessionQueue.async {
+                let settings: AVCapturePhotoSettings
+                if self.photoOutput.availablePhotoCodecTypes.contains(.jpeg) {
+                    settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+                } else {
+                    settings = AVCapturePhotoSettings()
+                }
+                settings.photoQualityPrioritization = .quality
+                self.photoOutput.capturePhoto(with: settings, delegate: self)
+            }
+        }
+    }
+
+    private func configureIfNeeded() {
+        guard isConfigured == false else {
+            resumeScanning()
+            return
+        }
+        guard authorizationInFlight == false else { return }
+
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            configureSession()
+        case .notDetermined:
+            authorizationInFlight = true
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    self.authorizationInFlight = false
+                    if granted {
+                        self.configureSession()
+                    } else {
+                        self.present(error: .permissionDenied)
+                    }
+                }
+            }
+        default:
+            present(error: .permissionDenied)
+        }
+    }
+
+    private func configureSession() {
+        state = .preparing
+        registerForNotifications()
+
+        sessionQueue.async {
+            guard self.isConfiguringSession == false else { return }
+
+            self.isConfiguringSession = true
+            self.session.beginConfiguration()
+            self.session.sessionPreset = .photo
+            var shouldStartSession = false
+
+            defer {
+                self.session.commitConfiguration()
+                self.isConfiguringSession = false
+
+                if shouldStartSession {
+                    self.startSessionIfNeeded()
+                }
+            }
+
+            guard let device = self.selectCaptureDevice() else {
+                DispatchQueue.main.async {
+                    self.present(error: .cameraUnavailable)
+                }
+                return
+            }
+
+            self.activeDevice = device
+
+            do {
+                let input = try AVCaptureDeviceInput(device: device)
+                guard self.session.inputs.isEmpty, self.session.canAddInput(input) else {
+                    DispatchQueue.main.async {
+                        self.present(error: .configurationFailed)
+                    }
+                    return
+                }
+                self.session.addInput(input)
+            } catch {
+                DispatchQueue.main.async {
+                    self.present(error: .system(error.localizedDescription))
+                }
+                return
+            }
+
+            do {
+                try self.configure(device: device)
+            } catch {
+                DispatchQueue.main.async {
+                    self.present(error: .system(error.localizedDescription))
+                }
+                return
+            }
+
+            self.videoOutput.alwaysDiscardsLateVideoFrames = true
+            self.videoOutput.setSampleBufferDelegate(self, queue: self.analysisQueue)
+            guard self.session.outputs.isEmpty, self.session.canAddOutput(self.videoOutput), self.session.canAddOutput(self.photoOutput) else {
+                DispatchQueue.main.async {
+                    self.present(error: .configurationFailed)
+                }
+                return
+            }
+
+            self.session.addOutput(self.videoOutput)
+            self.session.addOutput(self.photoOutput)
+            self.photoOutput.maxPhotoQualityPrioritization = .quality
+            self.frameThrottle = CACurrentMediaTime()
+            self.isConfigured = true
+            self.readinessPaused = false
+            shouldStartSession = true
+        }
+    }
+
+    nonisolated private func startSessionIfNeeded() {
+        guard isConfiguringSession == false else { return }
+
+        if session.isRunning == false {
+            session.startRunning()
+        }
+
+        DispatchQueue.main.async {
+            if self.session.isRunning {
+                self.state = .scanning
+                self.readiness = .none
+            } else {
+                self.present(error: .cameraUnavailable)
+            }
+        }
+    }
+
+    nonisolated private func selectCaptureDevice() -> AVCaptureDevice? {
+        let preferredTypes: [AVCaptureDevice.DeviceType] = [
+            .builtInTripleCamera,
+            .builtInDualWideCamera,
+            .builtInDualCamera,
+            .builtInWideAngleCamera
+        ]
+
+        let discovery = AVCaptureDevice.DiscoverySession(
+            deviceTypes: preferredTypes,
+            mediaType: .video,
+            position: .back
+        )
+        return discovery.devices.first ?? AVCaptureDevice.default(for: .video)
+    }
+
+    nonisolated private func configure(device: AVCaptureDevice) throws {
+        try device.lockForConfiguration()
+        defer { device.unlockForConfiguration() }
+
+        if device.isFocusModeSupported(.continuousAutoFocus) {
+            device.focusMode = .continuousAutoFocus
+        }
+        if device.isAutoFocusRangeRestrictionSupported {
+            device.autoFocusRangeRestriction = .near
+        }
+        if device.isSmoothAutoFocusSupported {
+            device.isSmoothAutoFocusEnabled = true
+        }
+        if device.isExposureModeSupported(.continuousAutoExposure) {
+            device.exposureMode = .continuousAutoExposure
+        }
+        if device.isLowLightBoostSupported {
+            device.automaticallyEnablesLowLightBoostWhenAvailable = true
+        }
+        if #available(iOS 17.0, *), device.isGeometricDistortionCorrectionSupported {
+            device.isGeometricDistortionCorrectionEnabled = true
+        }
+        device.isSubjectAreaChangeMonitoringEnabled = true
+        device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
+        device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+    }
+
+    private func registerForNotifications() {
+        guard isObservingSessionNotifications == false else { return }
+        isObservingSessionNotifications = true
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(handleRuntimeError(_:)), name: AVCaptureSession.runtimeErrorNotification, object: session)
+        center.addObserver(self, selector: #selector(handleInterruption(_:)), name: AVCaptureSession.wasInterruptedNotification, object: session)
+        center.addObserver(self, selector: #selector(handleInterruptionEnded(_:)), name: AVCaptureSession.interruptionEndedNotification, object: session)
+    }
+
+    private func unregisterForNotifications() {
+        guard isObservingSessionNotifications else { return }
+        isObservingSessionNotifications = false
+        NotificationCenter.default.removeObserver(self, name: AVCaptureSession.runtimeErrorNotification, object: session)
+        NotificationCenter.default.removeObserver(self, name: AVCaptureSession.wasInterruptedNotification, object: session)
+        NotificationCenter.default.removeObserver(self, name: AVCaptureSession.interruptionEndedNotification, object: session)
+    }
+
+    @objc
+    private func handleRuntimeError(_ notification: Notification) {
+        if let error = notification.userInfo?[AVCaptureSessionErrorKey] as? AVError, error.code == .mediaServicesWereReset {
+            sessionQueue.async {
+                self.startSessionIfNeeded()
+            }
+            return
+        }
+
+        present(error: .runtimeFailure)
+    }
+
+    @objc
+    private func handleInterruption(_ notification: Notification) {
+        readiness = .none
+        state = .error(CaptureError.interrupted.message)
+    }
+
+    @objc
+    private func handleInterruptionEnded(_ notification: Notification) {
+        resumeScanning()
+    }
+
+    private func present(error: CaptureError) {
+        state = .error(error.message)
+        readiness = .none
+        photoContinuation?.resume(throwing: error)
+        photoContinuation = nil
+    }
+
+    private func updateReadiness(using observations: [VNRecognizedTextObservation]) {
+        let candidates = observations.compactMap { observation -> VNRecognizedText? in
+            guard let candidate = observation.topCandidates(1).first else { return nil }
+            guard candidate.confidence >= max(0.3, ocrConfiguration.confidenceThreshold - 0.15) else { return nil }
+            return candidate
+        }
+
+        if candidates.isEmpty {
+            readiness = .tooFar
+            return
+        }
+
+        let combinedLength = candidates.reduce(0) { $0 + $1.string.count }
+        let averageConfidence = candidates.reduce(Float.zero) { $0 + $1.confidence } / Float(candidates.count)
+
+        if combinedLength >= 36 && averageConfidence >= 0.58 && candidates.count >= 4 {
+            readiness = .ready
+        } else {
+            readiness = .almostReady
+        }
+    }
+
+    enum CaptureError: LocalizedError {
+        case permissionDenied
+        case cameraUnavailable
+        case configurationFailed
+        case captureInProgress
+        case photoProcessingFailed
+        case runtimeFailure
+        case interrupted
+        case system(String)
+
+        var message: String {
+            switch self {
+            case .permissionDenied:
+                return "Enable camera access in Settings to scan ingredient labels."
+            case .cameraUnavailable:
+                return "Camera preview is unavailable on this device."
+            case .configurationFailed:
+                return "The camera could not be configured for label capture."
+            case .captureInProgress:
+                return "A label capture is already in progress."
+            case .photoProcessingFailed:
+                return "The captured photo could not be processed."
+            case .runtimeFailure:
+                return "The camera session was interrupted. Try retaking the label."
+            case .interrupted:
+                return "Camera access was interrupted. Return to the app to continue scanning."
+            case .system(let message):
+                return message
+            }
+        }
+
+        var errorDescription: String? { message }
+    }
+}
+
+extension LabelCaptureController: @preconcurrency AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard readinessPaused == false else { return }
+        let now = CACurrentMediaTime()
+        guard now - frameThrottle >= ocrConfiguration.frameThrottleInterval else { return }
+        frameThrottle = now
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let request = readinessRequest
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .right, options: [:])
+        do {
+            try handler.perform([request])
+            let observations = request.results ?? []
+            DispatchQueue.main.async {
+                if self.state == .scanning {
+                    self.updateReadiness(using: observations)
+                }
+            }
+        } catch {
+            DispatchQueue.main.async {
+                if self.state != .error(error.localizedDescription) {
+                    self.present(error: .runtimeFailure)
+                }
+            }
+        }
+    }
+}
+
+extension LabelCaptureController: AVCapturePhotoCaptureDelegate {
+    nonisolated func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        let dataResult: Result<Data, CaptureError>
+        if let error {
+            dataResult = .failure(.system(error.localizedDescription))
+        } else if let data = photo.fileDataRepresentation() {
+            dataResult = .success(data)
+        } else {
+            dataResult = .failure(.photoProcessingFailed)
+        }
+
+        DispatchQueue.main.async {
+            switch dataResult {
+            case .success(let data):
+                self.state = .paused
+                self.readiness = .none
+                self.photoContinuation?.resume(returning: data)
+                self.photoContinuation = nil
+            case .failure(let captureError):
+                self.present(error: captureError)
+            }
+        }
+    }
+}
+
+struct LabelCameraPreview: UIViewRepresentable {
+    let controller: LabelCaptureController
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.videoPreviewLayer.session = controller.session
+        view.videoPreviewLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {
+        if uiView.videoPreviewLayer.session !== controller.session {
+            uiView.videoPreviewLayer.session = controller.session
+        }
+    }
+
+    final class PreviewView: UIView {
+        override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        var videoPreviewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+    }
+}
+
+#else
+
+@MainActor
+@Observable
+final class LabelCaptureController {
+    private(set) var state: CaptureState = .idle
+    private(set) var readiness: CaptureReadiness = .none
+
+    func start() {}
+    func stop() {}
+    func resumeScanning() {}
+    func capturePhotoData() async throws -> Data { Data() }
+}
+
+#endif

--- a/PungentRoots/Camera/LiveCaptureController.swift
+++ b/PungentRoots/Camera/LiveCaptureController.swift
@@ -8,35 +8,9 @@ import os
 
 #if os(iOS)
 final class LiveCaptureController: NSObject, ObservableObject {
-    enum State: Equatable {
-        case idle
-        case preparing
-        case scanning
-        case processing
-        case paused
-        case error(String)
-    }
-
-    struct RecognizedPayload {
-        struct Item {
-            let text: String
-            let boundingBox: CGRect
-        }
-
-        let items: [Item]
-        let capturedImage: UIImage?
-
-        var strings: [String] {
-            items.map { $0.text }
-        }
-    }
-
-    enum ReadinessLevel: Equatable {
-        case none          // Not scanning or no feedback available
-        case tooFar        // Not enough text detected
-        case almostReady   // Text detected but quality not high enough
-        case ready         // All criteria met, will capture soon
-    }
+    typealias State = CaptureState
+    typealias RecognizedPayload = CapturePayload
+    typealias ReadinessLevel = CaptureReadiness
 
     @Published private(set) var state: State = .idle
     @Published private(set) var zoomFactor: CGFloat = 1.0
@@ -451,33 +425,9 @@ struct LiveCameraPreview: UIViewRepresentable {
 }
 #else
 final class LiveCaptureController: ObservableObject {
-    enum State: Equatable {
-        case idle
-        case preparing
-        case scanning
-        case processing
-        case paused
-        case error(String)
-    }
-
-    enum ReadinessLevel: Equatable {
-        case none
-        case tooFar
-        case almostReady
-        case ready
-    }
-
-    struct RecognizedPayload {
-        struct Item {
-            let text: String
-            let boundingBox: CGRect
-        }
-
-        let items: [Item]
-        let capturedImage: UIImage?
-
-        var strings: [String] { items.map { $0.text } }
-    }
+    typealias State = CaptureState
+    typealias ReadinessLevel = CaptureReadiness
+    typealias RecognizedPayload = CapturePayload
 
     @Published private(set) var state: State = .idle
     @Published private(set) var readiness: ReadinessLevel = .none
@@ -493,22 +443,3 @@ final class LiveCaptureController: ObservableObject {
     func setZoom(_ factor: CGFloat) {}
 }
 #endif
-
-extension LiveCaptureController.State {
-    var descriptor: (text: String, icon: String) {
-        switch self {
-        case .idle:
-            return ("Starting camera…", "camera")
-        case .preparing:
-            return ("Preparing camera…", "camera")
-        case .scanning:
-            return ("Hold steady for auto capture", "camera.viewfinder")
-        case .processing:
-            return ("Analyzing frame…", "wand.and.stars")
-        case .paused:
-            return ("Capture complete", "checkmark.circle")
-        case .error:
-            return ("Camera paused", "exclamationmark.triangle")
-        }
-    }
-}

--- a/PungentRoots/ContentView.swift
+++ b/PungentRoots/ContentView.swift
@@ -1,49 +1,54 @@
 import SwiftUI
-import os
 
 struct ContentView: View {
     @Environment(AppEnvironment.self) private var appEnvironment
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
-#if os(iOS)
-    @State private var captureController = AutoCaptureController(prefersDataScanner: true)
-    @State private var capturePreference = true
-#endif
-    @State private var normalizedPreview: String = ""
-    @State private var detectionResult: DetectionResult?
-    @State private var recognizedItems: [LiveCaptureController.RecognizedPayload.Item] = []
-    @State private var capturedImage: UIImage?
-    @State private var highlightedBoxes: [DetectionOverlay] = []
-    @State private var isProcessing = false
-    @State private var isShowingFullText = false
+    @State private var flowModel = ScanFlowModel()
     @State private var isShowingSettings = false
-    @State private var interfaceError: String?
+    @State private var didHandleLaunchArguments = false
 
-    private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "ScanFlow")
-#if os(iOS)
-    @ScaledMetric(relativeTo: .title2) private var baseCameraHeight: CGFloat = 340
-#endif
+    private let launchArguments = ProcessInfo.processInfo.arguments
 
     var body: some View {
         NavigationStack {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 20) {
-                    cameraModule
-                    resultCard
-                    guidanceLink
+                    ScanCameraModuleView(flowModel: flowModel)
+                    ScanActionBarView(flowModel: flowModel) {
+                        isShowingSettings = true
+                    }
+                    ScanResultSectionView(flowModel: flowModel)
+                    if flowModel.showsEmptyState {
+                        EmptyStateView()
+                            .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                    }
                 }
                 .padding(.vertical, 20)
                 .padding(.horizontal)
             }
-            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .background(
+                LinearGradient(
+                    colors: [
+                        Color(.systemGroupedBackground),
+                        Color(.secondarySystemGroupedBackground)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+            )
             .toolbar { toolbarContent }
-            .alert("Error", isPresented: Binding(
-                get: { interfaceError != nil },
-                set: { if !$0 { interfaceError = nil } }
-            )) {
-                Button("OK", role: .cancel) { interfaceError = nil }
+            .alert(
+                "Error",
+                isPresented: Binding(
+                    get: { flowModel.interfaceError != nil },
+                    set: { if !$0 { flowModel.dismissError() } }
+                )
+            ) {
+                Button("OK", role: .cancel) {
+                    flowModel.dismissError()
+                }
             } message: {
-                Text(interfaceError ?? "")
+                Text(flowModel.interfaceError ?? "")
             }
         }
         .navigationTitle(Text("scan.navigation.title"))
@@ -53,242 +58,19 @@ struct ContentView: View {
                 SettingsView()
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("common.done", action: { isShowingSettings = false })
+                            Button("common.done") {
+                                isShowingSettings = false
+                            }
                         }
                     }
             }
         }
-        .onAppear { configureCaptureController() }
-#if os(iOS)
-        .onDisappear { captureController.stop() }
-        .onChange(of: captureController.state) { _, state in
-            if case let .error(message) = state {
-                interfaceError = message
-            }
+        .task {
+            flowModel.bind(environment: appEnvironment)
+            handleLaunchArgumentsIfNeeded()
         }
-        .onChange(of: appEnvironment.captureOptions.prefersDataScanner) { _, _ in
-            configureCaptureController()
-        }
-#endif
-    }
-
-    private var cameraModule: some View {
-        VStack(spacing: 12) {
-            cameraPreviewContent
-        }
-    }
-
-    @ViewBuilder
-    private var cameraPreviewContent: some View {
-#if os(iOS)
-        ZStack {
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .fill(.thickMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 28, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.12), radius: 18, x: 0, y: 12)
-            GeometryReader { proxy in
-                Group {
-                    if captureController.isUsingDataScanner, let scanner = captureController.dataScannerController {
-                        DataScannerContainerView(controller: scanner)
-                    } else if let legacy = captureController.legacyController {
-                        LiveCameraPreview(controller: legacy)
-                            .overlay(alignmentGuides)
-                    } else {
-                        Color.black.opacity(0.6)
-                    }
-                }
-                .frame(width: proxy.size.width, height: proxy.size.height)
-                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-                .accessibilityElement(children: .contain)
-            }
-            .padding(6)
-        }
-        .frame(height: cameraHeight)
-        .frame(maxWidth: .infinity)
-        .overlay(statusBadgeOverlay, alignment: .topLeading)
-        .overlay(alignment: .center) {
-            if case .error = captureController.state {
-                errorOverlay
-            }
-        }
-        .padding(.horizontal, -16)
-#else
-        Text("Camera preview is available on iOS devices.")
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-#endif
-    }
-
-#if os(iOS)
-    private var cameraHeight: CGFloat {
-        let minimum: CGFloat = dynamicTypeSize.isAccessibilitySize ? 380 : 320
-        return max(minimum, baseCameraHeight)
-    }
-
-    private var alignmentGuides: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(Color.white.opacity(0.25), lineWidth: 1)
-            VStack {
-                Spacer()
-                Rectangle()
-                    .fill(Color.white.opacity(0.18))
-                    .frame(height: 1)
-                Spacer()
-            }
-            HStack {
-                Spacer()
-                Rectangle()
-                    .fill(Color.white.opacity(0.18))
-                    .frame(width: 1)
-                Spacer()
-            }
-        }
-        .accessibilityHidden(true)
-    }
-
-    private var statusBadgeOverlay: some View {
-        HStack {
-            statusBadge
-            Spacer()
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 16)
-    }
-
-    @ViewBuilder
-    private var statusBadge: some View {
-        let descriptor = statusDescriptor
-        let stateColor = descriptor.color
-
-        HStack(spacing: 8) {
-            // Animated status indicator
-            if captureController.state == .scanning || captureController.state == .processing {
-                Circle()
-                    .fill(stateColor)
-                    .frame(width: 6, height: 6)
-                    .overlay(
-                        Circle()
-                            .fill(stateColor.opacity(0.3))
-                            .scaleEffect(1.8)
-                    )
-                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: captureController.state)
-            }
-
-            Label(descriptor.text, systemImage: descriptor.icon)
-                .font(.footnote.weight(.semibold))
-                .symbolEffect(.pulse, options: .repeating, value: captureController.state == .processing)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .foregroundStyle(.white)
-        .background(
-            Capsule()
-                .fill(.ultraThinMaterial)
-        )
-        .background(
-            Capsule()
-                .strokeBorder(stateColor.opacity(0.35), lineWidth: 1)
-        )
-        .shadow(color: stateColor.opacity(0.3), radius: 8, x: 0, y: 2)
-        .accessibilityHint(Text("scan.status.accessibility.hint"))
-    }
-
-    private var statusDescriptor: (text: LocalizedStringKey, icon: String, color: Color) {
-        // When scanning, show readiness-based feedback
-        if captureController.state == .scanning {
-            switch captureController.readiness {
-            case .none:
-                let descriptor = captureController.state.descriptor
-                return (descriptor.text, descriptor.icon, .blue)
-            case .tooFar:
-                return (LocalizedStringKey("scan.status.move_closer"), "arrow.down.forward.and.arrow.up.backward", .orange)
-            case .almostReady:
-                return (LocalizedStringKey("scan.status.almost_ready"), "camera.metering.center.weighted", .yellow)
-            case .ready:
-                return (LocalizedStringKey("scan.status.ready"), "checkmark.circle", .green)
-            }
-        }
-
-        // Otherwise, use default state-based descriptor
-        let descriptor = captureController.state.descriptor
-        let color = statusColor(for: captureController.state)
-        return (descriptor.text, descriptor.icon, color)
-    }
-
-    private func statusColor(for state: AutoCaptureController.State) -> Color {
-        switch state {
-        case .idle, .preparing:
-            return .gray
-        case .scanning:
-            return .blue
-        case .processing:
-            return .orange
-        case .paused:
-            return .green
-        case .error:
-            return .red
-        }
-    }
-
-    private var errorOverlay: some View {
-        VStack(spacing: 12) {
-            Label("scan.error.title", systemImage: "exclamationmark.triangle.fill")
-                .font(.footnote.weight(.semibold))
-            Button {
-                captureController.resumeScanning()
-            } label: {
-                Label("scan.error.retry", systemImage: "arrow.clockwise")
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(.accentColor)
-        }
-        .padding(24)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .accessibilityElement(children: .combine)
-    }
-
-#endif
-
-    private var resultCard: some View {
-        Group {
-            if isProcessing {
-                card {
-                    ProcessingStateView()
-                }
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else if let result = detectionResult, !normalizedPreview.isEmpty {
-                card {
-                    DetectionResultView(
-                        normalizedText: normalizedPreview,
-                        result: result,
-                        capturedImage: capturedImage,
-                        detectionBoxes: highlightedBoxes,
-                        isShowingFullText: $isShowingFullText,
-                        onRescan: rescan
-                    )
-                }
-                .transition(.asymmetric(
-                    insertion: .move(edge: .bottom).combined(with: .opacity),
-                    removal: .move(edge: .leading).combined(with: .opacity)
-                ))
-            } else {
-                EmptyView()
-            }
-        }
-        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: isProcessing)
-        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: detectionResult?.verdict)
-    }
-
-    private var guidanceLink: some View {
-        Group {
-            if detectionResult == nil && !isProcessing {
-                EmptyStateView()
-                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
-            }
+        .onDisappear {
+            flowModel.stop()
         }
     }
 
@@ -298,161 +80,19 @@ struct ContentView: View {
             Button(action: { isShowingSettings = true }) {
                 Label("common.info", systemImage: "info.circle")
             }
+            .accessibilityIdentifier("open-settings")
         }
     }
 
-    private func configureCaptureController() {
-#if os(iOS)
-        let prefersDataScanner = appEnvironment.captureOptions.prefersDataScanner
-        if capturePreference != prefersDataScanner {
-            captureController.stop()
-            captureController = AutoCaptureController(prefersDataScanner: prefersDataScanner)
-            capturePreference = prefersDataScanner
+    private func handleLaunchArgumentsIfNeeded() {
+        guard didHandleLaunchArguments == false else { return }
+        didHandleLaunchArguments = true
+
+        if launchArguments.contains("--ui-test-open-settings") {
+            isShowingSettings = true
         }
-
-        captureController.setHandlers(
-            onCapture: { payload in
-                handleRecognizedText(payload)
-            },
-            onError: { message in
-                interfaceError = message
-            }
-        )
-
-        DispatchQueue.main.async {
-            captureController.start()
-        }
-#endif
-    }
-
-    private func handleRecognizedText(_ payload: LiveCaptureController.RecognizedPayload) {
-        logger.info("auto_capture_recognized lines=\(payload.items.count, privacy: .public)")
-
-        // Haptic feedback on capture
-        #if os(iOS)
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        #endif
-
-        Task { @MainActor in
-            isProcessing = true
-            detectionResult = nil
-            normalizedPreview = ""
-            isShowingFullText = false
-            highlightedBoxes = []
-            recognizedItems = payload.items
-            capturedImage = payload.capturedImage
-
-            let recognized = appEnvironment.textAcquisition.makeRecognizedText(from: payload.items.map { $0.text })
-            let analysis = await appEnvironment.analyzeAsync(recognized.normalized)
-
-            detectionResult = analysis.result
-            normalizedPreview = analysis.normalized
-            updateHighlights(for: analysis.result)
-            announceSummary(for: analysis.result)
-
-            #if os(iOS)
-            let feedback = UINotificationFeedbackGenerator()
-            switch analysis.result.verdict {
-            case .safe:
-                feedback.notificationOccurred(.success)
-            case .needsReview:
-                feedback.notificationOccurred(.warning)
-            case .contains:
-                feedback.notificationOccurred(.error)
-            }
-            #endif
-
-            isProcessing = false
-            captureController.finishProcessing()
-        }
-    }
-
-    private func announceSummary(for result: DetectionResult) {
-#if os(iOS)
-        let count = result.matches.count
-        let message: String
-        if count == 0 {
-            message = String(localized: "scan.summary.none")
-        } else if count == 1 {
-            message = String(localized: "scan.summary.single")
-        } else {
-            let format = NSLocalizedString("scan.summary.multiple", comment: "Announcement for multiple detection matches")
-            message = String(format: format, count)
-        }
-        UIAccessibility.post(notification: .announcement, argument: message)
-#endif
-    }
-
-    private func rescan() {
-        logger.info("auto_capture_rescan")
-
-        // Haptic feedback on button tap
-        #if os(iOS)
-        UISelectionFeedbackGenerator().selectionChanged()
-        #endif
-
-        normalizedPreview = ""
-        detectionResult = nil
-        isShowingFullText = false
-        isProcessing = false
-        highlightedBoxes = []
-        recognizedItems = []
-        capturedImage = nil
-#if os(iOS)
-        captureController.resumeScanning()
-#endif
-    }
-
-    private func updateHighlights(for result: DetectionResult) {
-        logger.debug("updateHighlights: recognizedItems=\(self.recognizedItems.count) matches=\(result.matches.count)")
-
-        var severityMap: [String: DetectionOverlay.DetectionSeverity] = [:]
-        for match in result.matches {
-            let key = match.term.lowercased()
-            let severity = DetectionOverlay.DetectionSeverity(kind: match.kind)
-            if let existing = severityMap[key], existing.priority >= severity.priority {
-                continue
-            }
-            severityMap[key] = severity
-        }
-
-        guard !severityMap.isEmpty else {
-            logger.debug("updateHighlights: severityMap is empty, clearing boxes")
-            highlightedBoxes = []
-            return
-        }
-
-        let orderedMap = severityMap.sorted { lhs, rhs in
-            lhs.value.priority > rhs.value.priority
-        }
-
-        var overlays: [DetectionOverlay] = []
-        for item in recognizedItems {
-            let lowered = item.text.lowercased()
-            logger.debug("updateHighlights: checking item text='\(lowered)'")
-            if let match = orderedMap.first(where: { lowered.contains($0.key) }) {
-                let severity = match.value
-                let matchedKey = match.key
-                logger.debug("updateHighlights: MATCHED '\(lowered)' with key '\(matchedKey)'")
-                overlays.append(DetectionOverlay(rect: item.boundingBox, severity: severity))
-            }
-        }
-        logger.debug("updateHighlights: created \(overlays.count) overlay boxes")
-        highlightedBoxes = overlays
-    }
-
-    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .padding(22)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.regularMaterial)
-                    .shadow(color: Color.black.opacity(0.08), radius: 14, x: 0, y: 10)
-            )
     }
 }
-
 
 private struct ContentViewPreviewHarness: View {
     @State private var environment = AppEnvironment.preview

--- a/PungentRoots/Models/CapturedLabel.swift
+++ b/PungentRoots/Models/CapturedLabel.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+
+struct RecognizedTextBlock: Identifiable, Equatable, Sendable {
+    let text: String
+    let boundingBox: CGRect
+    let confidence: Float
+
+    var id: String {
+        "\(text.lowercased())-\(boundingBox.origin.x)-\(boundingBox.origin.y)-\(boundingBox.width)-\(boundingBox.height)"
+    }
+}
+
+enum OCRCoverageStatus: String, Equatable, Sendable {
+    case complete
+    case partial
+    case insufficient
+
+    var title: String {
+        switch self {
+        case .complete:
+            return "Full label likely captured"
+        case .partial:
+            return "Ingredient list may be incomplete"
+        case .insufficient:
+            return "Only partial packaging text was read"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .complete:
+            return "This scan appears to include the ingredient panel."
+        case .partial:
+            return "Review the package and retake if the ingredient list is cut off."
+        case .insufficient:
+            return "The app may have read footer or allergen text instead of the full ingredients."
+        }
+    }
+}
+
+struct CapturedLabel: Equatable, Sendable {
+    let imageData: Data?
+    let recognizedBlocks: [RecognizedTextBlock]
+    let rawText: String
+    let coverageStatus: OCRCoverageStatus
+    let warnings: [String]
+}

--- a/PungentRoots/Models/Scan.swift
+++ b/PungentRoots/Models/Scan.swift
@@ -42,12 +42,12 @@ final class Scan {
     }
 }
 
-enum ScanSource: String, Codable, CaseIterable, Hashable {
+enum ScanSource: String, Codable, CaseIterable, Hashable, Sendable {
     case photo
     case paste
 }
 
-enum Verdict: String, Codable, CaseIterable, Hashable {
+enum Verdict: String, Codable, CaseIterable, Hashable, Sendable {
     case safe
     case needsReview
     case contains
@@ -67,7 +67,7 @@ struct Match: Codable, Hashable, Sendable {
     }
 }
 
-enum MatchKind: String, Codable, CaseIterable, Hashable {
+enum MatchKind: String, Codable, CaseIterable, Hashable, Sendable {
     case definite
     case synonym
     case pattern
@@ -88,7 +88,7 @@ enum MatchKind: String, Codable, CaseIterable, Hashable {
     }
 }
 
-struct DetectionResult {
+struct DetectionResult: Equatable, Sendable {
     let matches: [Match]
     let riskScore: Double
     let verdict: Verdict

--- a/PungentRoots/Models/ScanAnalysis.swift
+++ b/PungentRoots/Models/ScanAnalysis.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct ScanAnalysis: Equatable, Sendable {
+    let rawText: String
+    let normalizedText: String
+    let result: DetectionResult
+    let recognizedBlocks: [RecognizedTextBlock]
+    let coverageStatus: OCRCoverageStatus
+    let warnings: [String]
+    let capturedImageData: Data?
+
+    var matches: [Match] {
+        result.matches
+    }
+
+    var verdict: Verdict {
+        result.verdict
+    }
+
+    var hasWarnings: Bool {
+        warnings.isEmpty == false
+    }
+}

--- a/PungentRoots/OCR/PackagingTextAnalyzer.swift
+++ b/PungentRoots/OCR/PackagingTextAnalyzer.swift
@@ -1,0 +1,142 @@
+import CoreGraphics
+import Foundation
+
+enum PackagingTextAnalyzer {
+    static func mergeBlocks(_ blocks: [RecognizedTextBlock]) -> [RecognizedTextBlock] {
+        let sorted = blocks.sorted { lhs, rhs in
+            if lhs.confidence == rhs.confidence {
+                return lhs.text.count > rhs.text.count
+            }
+            return lhs.confidence > rhs.confidence
+        }
+
+        var merged: [RecognizedTextBlock] = []
+        for block in sorted {
+            let normalizedText = normalizedKey(for: block.text)
+            if let existingIndex = merged.firstIndex(where: { existing in
+                let existingText = normalizedKey(for: existing.text)
+                let overlap = intersectionOverUnion(block.boundingBox, existing.boundingBox)
+                let sameLine = abs(block.boundingBox.midY - existing.boundingBox.midY) < 0.03
+                let textMatches = existingText == normalizedText
+                return overlap > 0.72 || (sameLine && textMatches)
+            }) {
+                let existing = merged[existingIndex]
+                if block.confidence > existing.confidence || block.text.count > existing.text.count {
+                    merged[existingIndex] = block
+                }
+                continue
+            }
+            merged.append(block)
+        }
+
+        return merged.sorted(by: readingOrder)
+    }
+
+    static func coverageStatus(for blocks: [RecognizedTextBlock], rawText: String) -> OCRCoverageStatus {
+        let text = rawText.lowercased()
+        let ingredientIndicators = ["ingredients", "ingredient:"]
+        let footerIndicators = [
+            "distributed by",
+            "dist. & sold",
+            "dist & sold",
+            "contains sesame",
+            "contains soy",
+            "trader joe",
+            "product of",
+            "keep refrigerated",
+            "net wt"
+        ]
+
+        var score = 0
+        if ingredientIndicators.contains(where: text.contains) { score += 3 }
+
+        let commaCount = rawText.filter { $0 == "," }.count
+        switch commaCount {
+        case 4...:
+            score += 2
+        case 2...:
+            score += 1
+        default:
+            break
+        }
+
+        switch blocks.count {
+        case 8...:
+            score += 2
+        case 4...:
+            score += 1
+        default:
+            break
+        }
+
+        let textCoverage = blocks.reduce(CGFloat.zero) { partialResult, block in
+            partialResult + (block.boundingBox.width * block.boundingBox.height)
+        }
+        switch textCoverage {
+        case 0.18...:
+            score += 2
+        case 0.08...:
+            score += 1
+        default:
+            break
+        }
+
+        let footerHitCount = footerIndicators.reduce(into: 0) { total, indicator in
+            if text.contains(indicator) {
+                total += 1
+            }
+        }
+
+        if footerHitCount >= 2 && ingredientIndicators.contains(where: text.contains) == false {
+            score -= 2
+        }
+        if commaCount == 0 && blocks.count < 4 {
+            score -= 2
+        }
+
+        if score >= 5 {
+            return .complete
+        } else if score >= 2 {
+            return .partial
+        } else {
+            return .insufficient
+        }
+    }
+
+    static func warnings(for coverageStatus: OCRCoverageStatus, rawText: String) -> [String] {
+        switch coverageStatus {
+        case .complete:
+            return []
+        case .partial:
+            return ["This scan may not include the full ingredient list. Review the package and retake if needed."]
+        case .insufficient:
+            if rawText.lowercased().contains("contains ") {
+                return ["Only footer or allergen text was read. Retake the photo with the ingredient list centered and fully visible."]
+            }
+            return ["Only partial packaging text was read. The ingredient list may be missing from this scan."]
+        }
+    }
+
+    private static func normalizedKey(for text: String) -> String {
+        text
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .joined()
+    }
+
+    private static func readingOrder(lhs: RecognizedTextBlock, rhs: RecognizedTextBlock) -> Bool {
+        if abs(lhs.boundingBox.midY - rhs.boundingBox.midY) > 0.03 {
+            return lhs.boundingBox.midY > rhs.boundingBox.midY
+        }
+        return lhs.boundingBox.minX < rhs.boundingBox.minX
+    }
+
+    private static func intersectionOverUnion(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard intersection.isNull == false else { return 0 }
+        let intersectionArea = intersection.width * intersection.height
+        let unionArea = (lhs.width * lhs.height) + (rhs.width * rhs.height) - intersectionArea
+        guard unionArea > 0 else { return 0 }
+        return intersectionArea / unionArea
+    }
+}

--- a/PungentRoots/Resources/en.lproj/Localizable.strings
+++ b/PungentRoots/Resources/en.lproj/Localizable.strings
@@ -1,12 +1,13 @@
 "scan.navigation.title" = "Scan Ingredients";
 "scan.status.move_closer" = "Move closer to label";
-"scan.status.almost_ready" = "Almost ready—hold steady";
-"scan.status.ready" = "Capturing now…";
+"scan.status.almost_ready" = "Almost ready to capture";
+"scan.status.ready" = "Ready for a full-label scan";
 "scan.status.default_idle" = "Starting scanner…";
 "scan.status.default_preparing" = "Preparing scanner…";
-"scan.status.default_scanning" = "Hold steady for auto capture";
+"scan.status.default_scanning" = "Frame the full ingredient list";
+"scan.status.default_capturing" = "Capturing high-quality label photo…";
 "scan.status.default_processing" = "Analyzing frame…";
-"scan.status.default_paused" = "Capture complete";
+"scan.status.default_paused" = "Ready to review";
 "scan.status.default_error" = "Scanner paused";
 "scan.status.accessibility.hint" = "Scanner status updates as capture progresses.";
 "scan.error.title" = "Scanner unavailable";
@@ -19,17 +20,22 @@
 "common.info" = "Info";
 
 "settings.capture.heading" = "Capture";
-"settings.visionkit.toggle" = "VisionKit Auto Scanner";
-"settings.visionkit.description" = "Use Apple's Live Text pipeline when available for faster, on-device recognition.";
-"settings.visionkit.unsupported" = "VisionKit requires an A12 Bionic or newer device running iOS 16.";
+"settings.capture.full_label.title" = "Full-label still capture";
+"settings.capture.full_label.description" = "PungentRoots captures a full-resolution label photo before OCR so it can read ingredient panels instead of a single live-text snippet.";
 "settings.tips.title" = "Capture Tips";
 "settings.tips.fill_frame" = "Fill the frame with the ingredient list";
-"settings.tips.hold_steady" = "Hold steady while the camera focuses";
-"settings.tips.rescan" = "Rescan anytime to update results";
+"settings.tips.hold_steady" = "Reduce glare and hold steady before tapping Analyze Label";
+"settings.tips.rescan" = "Retake if the ingredient list is cut off or curved";
+
+"settings.quality.heading" = "Scan Quality";
+"settings.quality.complete.title" = "Complete label capture";
+"settings.quality.complete.description" = "A complete scan usually includes the ingredient header, dense ingredient text, and broad text coverage across the photo.";
+"settings.quality.partial.title" = "Why scans may need review";
+"settings.quality.partial.description" = "If the app sees only footer or allergen text, it avoids a Safe result and asks you to review or retake the label.";
 
 "settings.privacy.heading" = "Privacy";
 "settings.privacy.on_device.title" = "All processing on-device";
-"settings.privacy.on_device.description" = "Camera access powers automatic captures. No photos or text leave your device.";
+"settings.privacy.on_device.description" = "Camera access powers full-label OCR. No photos or text leave your device.";
 
 "settings.dictionary.heading" = "Detection Dictionary";
 "settings.dictionary.version" = "Version";
@@ -40,6 +46,8 @@
 "settings.support.heading" = "Support";
 "settings.support.fresh.title" = "Fresh Results";
 "settings.support.fresh.description" = "Scans are transient. Rescan for updated results with each label.";
+"settings.support.packaging.title" = "Packaging-first scanning";
+"settings.support.packaging.description" = "The scanner is tuned for glossy, curved, and off-center food labels instead of flat document pages.";
 
 "settings.navigation.title" = "Info & Settings";
-"settings.header.tagline" = "Detect alliums in ingredients instantly";
+"settings.header.tagline" = "Read full ingredient panels with packaging-aware OCR";

--- a/PungentRoots/Services/AppEnvironment+Fixtures.swift
+++ b/PungentRoots/Services/AppEnvironment+Fixtures.swift
@@ -4,18 +4,15 @@ extension AppEnvironment {
     static func live(bundle: Bundle = .main) -> AppEnvironment {
         do {
             let dictionary = try DictionaryLoader(bundle: bundle).load()
-            return AppEnvironment(
-                dictionary: dictionary,
-                captureOptions: defaultCaptureOptions()
-            )
+            return AppEnvironment(dictionary: dictionary)
         } catch {
             assertionFailure("Failed to load dictionary: \(error)")
-            return AppEnvironment(dictionary: .fallback, captureOptions: defaultCaptureOptions())
+            return AppEnvironment(dictionary: .fallback)
         }
     }
 
     static var preview: AppEnvironment {
-        AppEnvironment(dictionary: .preview, captureOptions: .init(prefersDataScanner: false))
+        AppEnvironment(dictionary: .preview)
     }
 }
 
@@ -41,17 +38,4 @@ private extension DetectDictionary {
             version: "fallback"
         )
     }
-}
-
-@MainActor
-private func defaultCaptureOptions() -> AppEnvironment.CaptureOptions {
-#if os(iOS)
-    if #available(iOS 16.0, *) {
-        return AppEnvironment.CaptureOptions(prefersDataScanner: DataScannerCaptureController.isSupported)
-    } else {
-        return AppEnvironment.CaptureOptions(prefersDataScanner: false)
-    }
-#else
-    return AppEnvironment.CaptureOptions(prefersDataScanner: false)
-#endif
 }

--- a/PungentRoots/Services/AppEnvironment.swift
+++ b/PungentRoots/Services/AppEnvironment.swift
@@ -5,15 +5,11 @@ import os
 @MainActor
 @Observable
 final class AppEnvironment {
-    struct CaptureOptions: Sendable {
-        var prefersDataScanner: Bool = true
-    }
-
     let detectionEngine: DetectionEngine
     let dictionary: DetectDictionary
     let normalizer: TextNormalizer
     let textAcquisition: TextAcquisitionService
-    var captureOptions: CaptureOptions
+    let scoring: DetectionScoring
 
     private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "Detection")
     private let signposter = OSSignposter(subsystem: "co.ouchieco.PungentRoots", category: "Detection")
@@ -21,21 +17,20 @@ final class AppEnvironment {
     init(
         dictionary: DetectDictionary,
         normalizer: TextNormalizer = TextNormalizer(),
-        scoring: DetectionScoring = .default,
-        captureOptions: CaptureOptions = .init()
+        scoring: DetectionScoring = .default
     ) {
         self.dictionary = dictionary
         self.normalizer = normalizer
+        self.scoring = scoring
         self.detectionEngine = DetectionEngine(dictionary: dictionary, normalizer: normalizer, scoring: scoring)
         self.textAcquisition = TextAcquisitionService(normalizer: normalizer)
-        self.captureOptions = captureOptions
 
 #if canImport(MetricKit)
         _ = MetricReporter.shared
 #endif
     }
 
-    func analyze(_ rawText: String) -> (normalized: String, result: DetectionResult) {
+    func analyze(_ rawText: String) -> ScanAnalysis {
         let signpostID = signposter.makeSignpostID()
         let interval = signposter.beginInterval("SynchronousAnalyze", id: signpostID)
         let start = DispatchTime.now()
@@ -43,10 +38,18 @@ final class AppEnvironment {
         let duration = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
         signposter.endInterval("SynchronousAnalyze", interval)
         logger.debug("Detection completed in \(duration, format: .fixed(precision: 2))ms (\(analysis.result.matches.count) matches)")
-        return analysis
+        return ScanAnalysis(
+            rawText: rawText,
+            normalizedText: analysis.normalized,
+            result: analysis.result,
+            recognizedBlocks: [],
+            coverageStatus: .complete,
+            warnings: [],
+            capturedImageData: nil
+        )
     }
 
-    func analyzeAsync(_ rawText: String) async -> (normalized: String, result: DetectionResult) {
+    func analyzeAsync(_ rawText: String) async -> ScanAnalysis {
         let engine = detectionEngine
         let signposter = self.signposter
         let result = await Task(priority: .userInitiated) { () -> (String, DetectionResult, Double) in
@@ -60,6 +63,49 @@ final class AppEnvironment {
         }.value
 
         logger.debug("Async detection completed in \(result.2, format: .fixed(precision: 2))ms (\(result.1.matches.count) matches)")
-        return (result.0, result.1)
+        return ScanAnalysis(
+            rawText: rawText,
+            normalizedText: result.0,
+            result: result.1,
+            recognizedBlocks: [],
+            coverageStatus: .complete,
+            warnings: [],
+            capturedImageData: nil
+        )
+    }
+
+    func analyzeCapturedLabel(_ label: CapturedLabel) -> ScanAnalysis {
+        let signpostID = signposter.makeSignpostID()
+        let interval = signposter.beginInterval("CapturedLabelAnalyze", id: signpostID)
+        let analysis = detectionEngine.analyze(rawText: label.rawText)
+        signposter.endInterval("CapturedLabelAnalyze", interval)
+        let result = adjustedDetectionResult(analysis.result, coverageStatus: label.coverageStatus)
+
+        return ScanAnalysis(
+            rawText: label.rawText,
+            normalizedText: analysis.normalized,
+            result: result,
+            recognizedBlocks: label.recognizedBlocks,
+            coverageStatus: label.coverageStatus,
+            warnings: label.warnings,
+            capturedImageData: label.imageData
+        )
+    }
+
+    func analyzeCapturedImageData(_ imageData: Data) async throws -> ScanAnalysis {
+        let label = try await textAcquisition.recognizePackaging(from: .imageData(imageData))
+        return analyzeCapturedLabel(label)
+    }
+
+    private func adjustedDetectionResult(_ result: DetectionResult, coverageStatus: OCRCoverageStatus) -> DetectionResult {
+        guard result.verdict == .safe, coverageStatus != .complete else {
+            return result
+        }
+
+        return DetectionResult(
+            matches: result.matches,
+            riskScore: max(result.riskScore, scoring.needsReviewThreshold),
+            verdict: .needsReview
+        )
     }
 }

--- a/PungentRoots/Services/MetricReporter.swift
+++ b/PungentRoots/Services/MetricReporter.swift
@@ -1,11 +1,11 @@
 #if canImport(MetricKit)
 
 import Foundation
-import MetricKit
+@preconcurrency import MetricKit
 import os
 
 @MainActor
-final class MetricReporter: NSObject, MXMetricManagerSubscriber {
+final class MetricReporter: NSObject, @preconcurrency MXMetricManagerSubscriber {
     static let shared = MetricReporter()
 
     private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "Metrics")

--- a/PungentRoots/Services/ScanFlowModel.swift
+++ b/PungentRoots/Services/ScanFlowModel.swift
@@ -1,0 +1,289 @@
+import Foundation
+import Observation
+import os
+#if os(iOS)
+import UIKit
+#endif
+
+@MainActor
+@Observable
+final class ScanFlowModel {
+    enum Phase: Equatable {
+        case framing
+        case capturing
+        case analyzing
+        case result
+    }
+
+    private let logger = Logger(subsystem: "co.ouchieco.PungentRoots", category: "ScanFlow")
+    private let launchArguments: [String]
+
+    private(set) var phase: Phase = .framing
+    private(set) var analysis: ScanAnalysis?
+    private(set) var highlightedBoxes: [DetectionOverlay] = []
+    private(set) var interfaceError: String?
+    private(set) var captureController: LabelCaptureController?
+    var isShowingFullText = false
+
+    @ObservationIgnored
+    private var appEnvironment: AppEnvironment?
+
+    @ObservationIgnored
+    private var scanTask: Task<Void, Never>?
+
+    @ObservationIgnored
+    private var didLoadUITestPreview = false
+
+    init(launchArguments: [String] = ProcessInfo.processInfo.arguments) {
+        self.launchArguments = launchArguments
+    }
+
+    var normalizedText: String {
+        analysis?.normalizedText ?? ""
+    }
+
+    var detectionResult: DetectionResult? {
+        analysis?.result
+    }
+
+    var captureState: CaptureState {
+        if isLiveCaptureDisabled {
+            switch phase {
+            case .framing:
+                return .scanning
+            case .capturing, .analyzing:
+                return .processing
+            case .result:
+                return .paused
+            }
+        }
+        return captureController?.state ?? .idle
+    }
+
+    var captureReadiness: CaptureReadiness {
+        if isLiveCaptureDisabled {
+            return phase == .result ? .ready : .none
+        }
+        return captureController?.readiness ?? .none
+    }
+
+    var isProcessing: Bool {
+        phase == .capturing || phase == .analyzing
+    }
+
+    var showsEmptyState: Bool {
+        phase == .framing && analysis == nil && isProcessing == false
+    }
+
+    var canAnalyzeLabel: Bool {
+        phase == .framing && interfaceError == nil
+    }
+
+    func bind(environment: AppEnvironment) {
+        appEnvironment = environment
+
+        if showsUITestPreviewResult {
+            loadUITestPreviewResultIfNeeded(using: environment)
+            return
+        }
+
+        if showsUITestPartialResult {
+            loadUITestPartialResultIfNeeded(using: environment)
+            return
+        }
+
+        if captureController == nil, isLiveCaptureDisabled == false {
+            let controller = LabelCaptureController()
+            captureController = controller
+            controller.start()
+        }
+    }
+
+    func captureLabel() {
+        guard canAnalyzeLabel else { return }
+        guard let environment = appEnvironment else {
+            interfaceError = "App environment is unavailable."
+            return
+        }
+
+        logger.info("capture_label_requested")
+        cancelWork()
+        interfaceError = nil
+        isShowingFullText = false
+        phase = .capturing
+
+        if isLiveCaptureDisabled {
+            phase = .analyzing
+            scanTask = Task { [weak self] in
+                guard let self else { return }
+                let analysis = self.makeUITestPartialResult(using: environment)
+                guard Task.isCancelled == false else { return }
+                await MainActor.run {
+                    self.apply(analysis: analysis)
+                }
+            }
+            return
+        }
+
+        scanTask = Task { [weak self] in
+            guard let self, let controller = self.captureController else { return }
+
+            do {
+                let imageData = try await controller.capturePhotoData()
+                guard Task.isCancelled == false else { return }
+
+                await MainActor.run {
+                    self.phase = .analyzing
+                }
+
+                let analysis = try await environment.analyzeCapturedImageData(imageData)
+                guard Task.isCancelled == false else { return }
+
+                await MainActor.run {
+                    self.apply(analysis: analysis)
+                }
+            } catch {
+                guard Task.isCancelled == false else { return }
+                await MainActor.run {
+                    self.phase = .framing
+                    self.interfaceError = error.localizedDescription
+                    self.captureController?.resumeScanning()
+                }
+            }
+        }
+    }
+
+    func rescan() {
+        logger.info("label_rescan_requested")
+        cancelWork()
+
+#if os(iOS)
+        UISelectionFeedbackGenerator().selectionChanged()
+#endif
+
+        analysis = nil
+        highlightedBoxes = []
+        isShowingFullText = false
+        interfaceError = nil
+        phase = .framing
+        captureController?.resumeScanning()
+    }
+
+    func dismissError() {
+        interfaceError = nil
+    }
+
+    func stop() {
+        cancelWork()
+        captureController?.stop()
+    }
+
+    private func apply(analysis: ScanAnalysis) {
+        self.analysis = analysis
+        highlightedBoxes = DetectionOverlay.overlays(for: analysis.recognizedBlocks, matches: analysis.result.matches)
+        phase = .result
+        announceSummary(for: analysis)
+        provideVerdictFeedback(for: analysis.result.verdict)
+    }
+
+    private func cancelWork() {
+        scanTask?.cancel()
+        scanTask = nil
+    }
+
+    private func loadUITestPreviewResultIfNeeded(using environment: AppEnvironment) {
+        guard didLoadUITestPreview == false else { return }
+        didLoadUITestPreview = true
+        apply(analysis: environment.analyzeCapturedLabel(makePreviewLabel()))
+    }
+
+    private func loadUITestPartialResultIfNeeded(using environment: AppEnvironment) {
+        guard didLoadUITestPreview == false else { return }
+        didLoadUITestPreview = true
+        apply(analysis: makeUITestPartialResult(using: environment))
+    }
+
+    private func makeUITestPartialResult(using environment: AppEnvironment) -> ScanAnalysis {
+        environment.analyzeCapturedLabel(
+            CapturedLabel(
+                imageData: nil,
+                recognizedBlocks: [
+                    RecognizedTextBlock(
+                        text: "Contains Sesame. Dist & sold exclusively by Trader Joe's",
+                        boundingBox: CGRect(x: 0.08, y: 0.54, width: 0.82, height: 0.14),
+                        confidence: 0.92
+                    )
+                ],
+                rawText: "Contains Sesame. Dist & sold exclusively by Trader Joe's",
+                coverageStatus: .insufficient,
+                warnings: PackagingTextAnalyzer.warnings(
+                    for: .insufficient,
+                    rawText: "Contains Sesame. Dist & sold exclusively by Trader Joe's"
+                )
+            )
+        )
+    }
+
+    private func makePreviewLabel() -> CapturedLabel {
+        CapturedLabel(
+            imageData: nil,
+            recognizedBlocks: [
+                RecognizedTextBlock(
+                    text: "Ingredients: wheat flour, onion powder, garlic extract, salt",
+                    boundingBox: CGRect(x: 0.08, y: 0.56, width: 0.84, height: 0.18),
+                    confidence: 0.96
+                )
+            ],
+            rawText: "Ingredients: wheat flour, onion powder, garlic extract, salt",
+            coverageStatus: .complete,
+            warnings: []
+        )
+    }
+
+    private func announceSummary(for analysis: ScanAnalysis) {
+#if os(iOS)
+        let result = analysis.result
+        let message: String
+        if analysis.coverageStatus == .complete {
+            let count = result.matches.count
+            if count == 0 {
+                message = String(localized: "scan.summary.none")
+            } else if count == 1 {
+                message = String(localized: "scan.summary.single")
+            } else {
+                let format = NSLocalizedString("scan.summary.multiple", comment: "Announcement for multiple detection matches")
+                message = String(format: format, count)
+            }
+        } else {
+            message = analysis.coverageStatus.subtitle
+        }
+        UIAccessibility.post(notification: .announcement, argument: message)
+#endif
+    }
+
+    private func provideVerdictFeedback(for verdict: Verdict) {
+#if os(iOS)
+        let feedback = UINotificationFeedbackGenerator()
+        switch verdict {
+        case .safe:
+            feedback.notificationOccurred(.success)
+        case .needsReview:
+            feedback.notificationOccurred(.warning)
+        case .contains:
+            feedback.notificationOccurred(.error)
+        }
+#endif
+    }
+
+    private var isLiveCaptureDisabled: Bool {
+        launchArguments.contains("--ui-test-disable-capture")
+    }
+
+    private var showsUITestPreviewResult: Bool {
+        launchArguments.contains("--ui-test-preview-result")
+    }
+
+    private var showsUITestPartialResult: Bool {
+        launchArguments.contains("--ui-test-preview-partial-result")
+    }
+}

--- a/PungentRoots/Services/TextAcquisitionService.swift
+++ b/PungentRoots/Services/TextAcquisitionService.swift
@@ -1,6 +1,10 @@
 import Foundation
 import os
+import CoreGraphics
 import Vision
+#if os(iOS)
+import UIKit
+#endif
 
 struct TextAcquisitionService {
     struct RecognizedText {
@@ -62,8 +66,104 @@ struct TextAcquisitionService {
         return recognized
     }
 
+    func recognizePackaging(from source: Source) async throws -> CapturedLabel {
+        let prepared = try prepareImage(from: source)
+        let blocks = try recognizeBlocks(in: RecognitionJob(cgImage: prepared.cgImage))
+        let mergedBlocks = PackagingTextAnalyzer.mergeBlocks(blocks)
+
+        guard mergedBlocks.isEmpty == false else {
+            throw Error.noTextFound
+        }
+
+        let rawText = mergedBlocks.map(\.text).joined(separator: "\n")
+        let coverageStatus = PackagingTextAnalyzer.coverageStatus(for: mergedBlocks, rawText: rawText)
+        let warnings = PackagingTextAnalyzer.warnings(for: coverageStatus, rawText: rawText)
+
+        logger.debug(
+            "Packaging OCR completed with \(mergedBlocks.count, privacy: .public) blocks coverage=\(coverageStatus.rawValue, privacy: .public)"
+        )
+
+        return CapturedLabel(
+            imageData: prepared.imageData,
+            recognizedBlocks: mergedBlocks,
+            rawText: rawText,
+            coverageStatus: coverageStatus,
+            warnings: warnings
+        )
+    }
+
     func makeRecognizedText(from strings: [String]) -> RecognizedText {
         let joined = strings.joined(separator: "\n")
         return RecognizedText(raw: joined, normalized: normalizer.normalize(joined))
     }
+
+    private func prepareImage(from source: Source) throws -> PreparedImage {
+        switch source {
+        case .cgImage(let cgImage):
+            return PreparedImage(cgImage: cgImage, imageData: nil)
+        case .imageData(let data):
+#if os(iOS)
+            guard let image = UIImage(data: data), let normalized = image.normalizedOrientationImage() else {
+                throw Error.unsupportedImage
+            }
+        return PreparedImage(cgImage: normalized, imageData: data)
+#else
+            throw Error.unsupportedImage
+#endif
+        }
+    }
+
+    private func recognizeBlocks(in job: RecognitionJob) throws -> [RecognizedTextBlock] {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = ocrConfig.recognitionLevel
+        request.usesLanguageCorrection = ocrConfig.usesLanguageCorrection
+        request.recognitionLanguages = ocrConfig.recognitionLanguages
+        request.minimumTextHeight = ocrConfig.minimumTextHeight
+        request.revision = ocrConfig.revision
+
+        let handler = VNImageRequestHandler(cgImage: job.cgImage)
+        do {
+            try handler.perform([request])
+        } catch {
+            throw Error.recognitionFailed(error)
+        }
+
+        let observations = request.results ?? []
+        return observations.compactMap { observation in
+            guard let candidate = observation.topCandidates(1).first else { return nil }
+            let trimmed = candidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false else { return nil }
+            guard candidate.confidence >= ocrConfig.confidenceThreshold else { return nil }
+            return RecognizedTextBlock(
+                text: trimmed,
+                boundingBox: observation.boundingBox,
+                confidence: candidate.confidence
+            )
+        }
+    }
+
+    private struct PreparedImage {
+        let cgImage: CGImage
+        let imageData: Data?
+    }
+
+    private struct RecognitionJob {
+        let cgImage: CGImage
+    }
 }
+
+#if os(iOS)
+private extension UIImage {
+    func normalizedOrientationImage() -> CGImage? {
+        if imageOrientation == .up, let cgImage {
+            return cgImage
+        }
+
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+        return image.cgImage
+    }
+}
+#endif

--- a/PungentRoots/Views/AdaptiveGlass.swift
+++ b/PungentRoots/Views/AdaptiveGlass.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+@ViewBuilder
+func adaptiveGlassGroup<Content: View>(
+    spacing: CGFloat = 16,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    if #available(iOS 26.0, *) {
+        GlassEffectContainer(spacing: spacing) {
+            content()
+        }
+    } else {
+        content()
+    }
+}
+
+private struct AdaptiveCardSurfaceModifier: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .shadow(color: Color.black.opacity(0.08), radius: 14, x: 0, y: 10)
+        } else {
+            content
+                .background(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .fill(.regularMaterial)
+                        .shadow(color: Color.black.opacity(0.08), radius: 14, x: 0, y: 10)
+                )
+        }
+    }
+}
+
+private struct AdaptiveBadgeSurfaceModifier: ViewModifier {
+    let tint: Color
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(
+                    .regular
+                        .tint(tint.opacity(0.14))
+                        .interactive(),
+                    in: Capsule()
+                )
+        } else {
+            content
+                .background(Capsule().fill(.ultraThinMaterial))
+                .overlay(
+                    Capsule()
+                        .strokeBorder(tint.opacity(0.35), lineWidth: 1)
+                )
+        }
+    }
+}
+
+extension View {
+    func adaptiveCardSurface(cornerRadius: CGFloat = 24) -> some View {
+        modifier(AdaptiveCardSurfaceModifier(cornerRadius: cornerRadius))
+    }
+
+    func adaptiveBadgeSurface(tint: Color) -> some View {
+        modifier(AdaptiveBadgeSurfaceModifier(tint: tint))
+    }
+
+    @ViewBuilder
+    func adaptivePrimaryButtonStyle() -> some View {
+        if #available(iOS 26.0, *) {
+            buttonStyle(.glassProminent)
+        } else {
+            buttonStyle(.borderedProminent)
+        }
+    }
+}

--- a/PungentRoots/Views/CapturedImageOverlayView.swift
+++ b/PungentRoots/Views/CapturedImageOverlayView.swift
@@ -31,9 +31,6 @@ struct CapturedImageOverlayView: View {
                             x: imageOffset.x - imageSize.width / 2 + transformedRect.minX,
                             y: imageOffset.y - imageSize.height / 2 + transformedRect.minY
                         )
-                        .onAppear {
-                            print("📦 Box: transformed=\(transformedRect) imageSize=\(imageSize) imageOffset=\(imageOffset)")
-                        }
                 }
             }
             .frame(width: geometry.size.width, height: geometry.size.height, alignment: .center)
@@ -67,48 +64,12 @@ struct CapturedImageOverlayView: View {
         return CGPoint(x: x + imageSize.width / 2, y: y + imageSize.height / 2)
     }
 
-    /// Transform Vision framework bounding box to SwiftUI coordinates
-    /// Vision uses bottom-left origin (0,0) with normalized coordinates (0-1)
-    /// SwiftUI uses top-left origin with pixel coordinates
     private func transformVisionRect(_ visionRect: CGRect, imageSize: CGSize) -> CGRect {
-        // The UIImage already has the correct orientation applied
-        // Vision coordinates are in the ORIGINAL sensor orientation (landscape)
-        // UIImage.size reflects the ROTATED dimensions (portrait after .right rotation)
-        // So we need to map from landscape Vision coords to portrait image coords
-
-        print("🔧 Transform: orientation=\(image.imageOrientation.rawValue) visionRect=\(visionRect) imageSize=\(imageSize)")
-
-        let x: CGFloat
-        let y: CGFloat
-        let width: CGFloat
-        let height: CGFloat
-
-        // Check if the image is portrait but Vision detected in landscape orientation
-        // This happens when camera sensor is landscape but UIImage is rotated to portrait
-        let isPortraitImage = imageSize.height > imageSize.width
-        let isLandscapeVisionBox = visionRect.height > visionRect.width
-
-        if isPortraitImage && isLandscapeVisionBox {
-            // Image is portrait, but Vision box is landscape (height > width)
-            // This means Vision coordinates are in sensor space (landscape)
-            // and we need to rotate them to match the portrait image
-            print("🔄 Detected landscape Vision box on portrait image - rotating coordinates")
-
-            // Rotate 90° clockwise: swap X/Y and swap width/height
-            x = visionRect.minY * imageSize.width
-            y = (1 - visionRect.maxX) * imageSize.height
-            width = visionRect.height * imageSize.width   // Swap width/height
-            height = visionRect.width * imageSize.height
-        } else {
-            // Standard transformation: flip Y axis from bottom-left to top-left
-            x = visionRect.minX * imageSize.width
-            y = (1 - visionRect.maxY) * imageSize.height
-            width = visionRect.width * imageSize.width
-            height = visionRect.height * imageSize.height
-        }
-
-        let result = CGRect(x: x, y: y, width: width, height: height)
-        print("🔧 Result: \(result)")
-        return result
+        CGRect(
+            x: visionRect.minX * imageSize.width,
+            y: (1 - visionRect.maxY) * imageSize.height,
+            width: visionRect.width * imageSize.width,
+            height: visionRect.height * imageSize.height
+        )
     }
 }

--- a/PungentRoots/Views/DetectionOverlayView.swift
+++ b/PungentRoots/Views/DetectionOverlayView.swift
@@ -1,11 +1,14 @@
 import SwiftUI
 
-struct DetectionOverlay {
-    let id = UUID()
+struct DetectionOverlay: Identifiable, Equatable {
     let rect: CGRect
     let severity: DetectionSeverity
 
-    enum DetectionSeverity {
+    var id: String {
+        "\(rect.origin.x)-\(rect.origin.y)-\(rect.size.width)-\(rect.size.height)-\(severity.priority)"
+    }
+
+    enum DetectionSeverity: Equatable {
         case high
         case medium
         case review
@@ -37,6 +40,72 @@ struct DetectionOverlay {
                 self = .review
             }
         }
+    }
+
+    static func overlays(for items: [RecognizedTextBlock], matches: [Match]) -> [DetectionOverlay] {
+        var severityMap: [String: DetectionSeverity] = [:]
+        for match in matches {
+            let key = normalizedSearchText(match.term)
+            let severity = DetectionSeverity(kind: match.kind)
+            if let existing = severityMap[key], existing.priority >= severity.priority {
+                continue
+            }
+            severityMap[key] = severity
+        }
+
+        guard !severityMap.isEmpty else {
+            return []
+        }
+
+        let orderedMap = severityMap.sorted { lhs, rhs in
+            lhs.value.priority > rhs.value.priority
+        }
+
+        let overlays = items.compactMap { item -> DetectionOverlay? in
+            let normalizedItemText = normalizedSearchText(item.text)
+            guard let severity = orderedMap.first(where: { containsNormalizedTerm($0.key, in: normalizedItemText) })?.value else {
+                return nil
+            }
+
+            return DetectionOverlay(rect: item.boundingBox, severity: severity)
+        }
+
+        var deduplicated: [DetectionOverlay] = []
+        for overlay in overlays {
+            if let existingIndex = deduplicated.firstIndex(where: {
+                intersectionOverUnion($0.rect, overlay.rect) > 0.72
+            }) {
+                if overlay.severity.priority > deduplicated[existingIndex].severity.priority {
+                    deduplicated[existingIndex] = overlay
+                }
+            } else {
+                deduplicated.append(overlay)
+            }
+        }
+
+        return deduplicated
+    }
+
+    private static func normalizedSearchText(_ text: String) -> String {
+        let collapsed = text
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.isEmpty == false }
+            .joined(separator: " ")
+        return " \(collapsed) "
+    }
+
+    private static func containsNormalizedTerm(_ term: String, in text: String) -> Bool {
+        text.contains(" \(term) ")
+    }
+
+    private static func intersectionOverUnion(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard intersection.isNull == false else { return 0 }
+        let intersectionArea = intersection.width * intersection.height
+        let unionArea = (lhs.width * lhs.height) + (rhs.width * rhs.height) - intersectionArea
+        guard unionArea > 0 else { return 0 }
+        return intersectionArea / unionArea
     }
 }
 

--- a/PungentRoots/Views/DetectionResultView.swift
+++ b/PungentRoots/Views/DetectionResultView.swift
@@ -1,12 +1,10 @@
 import SwiftUI
 
 struct DetectionResultView: View {
-    let normalizedText: String
-    let result: DetectionResult
+    let analysis: ScanAnalysis
     let capturedImage: UIImage?
     let detectionBoxes: [DetectionOverlay]
     @Binding var isShowingFullText: Bool
-    let onRescan: () -> Void
 
     @State private var showingHighInfo = false
     @State private var showingMediumInfo = false
@@ -14,10 +12,13 @@ struct DetectionResultView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            // Verdict badge at top with animation
-            VerdictBadge(verdict: result.verdict)
+            VerdictBadge(verdict: analysis.result.verdict)
                 .transition(.scale.combined(with: .opacity))
-                .animation(.spring(response: 0.5, dampingFraction: 0.7), value: result.verdict)
+                .animation(.spring(response: 0.5, dampingFraction: 0.7), value: analysis.result.verdict)
+
+            if analysis.hasWarnings {
+                qualityWarningSection
+            }
 
             if let image = capturedImage, !detectionBoxes.isEmpty {
                 capturedImageSection(image: image)
@@ -29,11 +30,40 @@ struct DetectionResultView: View {
 
             disclosureSection
                 .transition(.opacity)
-
-            actionButtonsSection
-                .transition(.move(edge: .bottom).combined(with: .opacity))
         }
-        .animation(.easeOut(duration: 0.3), value: result.matches.count)
+        .animation(.easeOut(duration: 0.3), value: analysis.result.matches.count)
+    }
+
+    private var qualityWarningSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(analysis.coverageStatus.title, systemImage: qualityIcon)
+                .font(.headline)
+                .foregroundStyle(qualityTint)
+
+            Text(analysis.coverageStatus.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            ForEach(analysis.warnings, id: \.self) { warning in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundStyle(qualityTint)
+                        .padding(.top, 2)
+                    Text(warning)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(qualityTint.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(qualityTint.opacity(0.22), lineWidth: 1)
+        )
     }
 
     @ViewBuilder
@@ -100,8 +130,11 @@ struct DetectionResultView: View {
                     .font(.system(size: 10))
                     .foregroundStyle(color.opacity(0.6))
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
         }
         .buttonStyle(.plain)
+        .adaptiveBadgeSurface(tint: color)
         .popover(isPresented: isShowing) {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 8) {
@@ -133,7 +166,7 @@ struct DetectionResultView: View {
     private var matchesSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             if uniqueMatches.isEmpty {
-                Text("No matches were detected.")
+                Text(analysis.coverageStatus == .complete ? "No matches were detected." : "No definite matches were detected in the captured text.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             } else {
@@ -162,36 +195,17 @@ struct DetectionResultView: View {
             .accessibilityIdentifier("toggle-scanned-text")
 
             if isShowingFullText {
-                HighlightedTextView(text: normalizedText, matches: result.matches)
+                HighlightedTextView(text: analysis.normalizedText, matches: analysis.result.matches)
                     .frame(maxHeight: 260)
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
     }
 
-    private var actionButtonsSection: some View {
-        VStack(spacing: 12) {
-            Divider()
-                .padding(.vertical, 8)
-
-            // Primary action: Scan another
-            Button(action: onRescan) {
-                Label("Scan Another Label", systemImage: "camera.rotate")
-                    .font(.body.weight(.semibold))
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .accessibilityLabel("Scan another label")
-            .accessibilityHint("Returns to camera to scan a new ingredient label")
-
-        }
-    }
-
     private var uniqueMatches: [MatchSummary] {
         var accumulator: [String: MatchAccumulator] = [:]
 
-        for match in result.matches {
+        for match in analysis.result.matches {
             let key = match.term.lowercased()
             let display = displayName(for: match.term)
             let current = accumulator[key]
@@ -207,6 +221,28 @@ struct DetectionResultView: View {
                 }
                 return lhs.priority > rhs.priority
             }
+    }
+
+    private var qualityTint: Color {
+        switch analysis.coverageStatus {
+        case .complete:
+            return .green
+        case .partial:
+            return .orange
+        case .insufficient:
+            return .red
+        }
+    }
+
+    private var qualityIcon: String {
+        switch analysis.coverageStatus {
+        case .complete:
+            return "checkmark.seal.fill"
+        case .partial:
+            return "exclamationmark.triangle.fill"
+        case .insufficient:
+            return "camera.aperture"
+        }
     }
 
     private func displayName(for term: String) -> String {

--- a/PungentRoots/Views/EmptyStateView.swift
+++ b/PungentRoots/Views/EmptyStateView.swift
@@ -4,21 +4,17 @@ import SwiftUI
 struct EmptyStateView: View {
     var body: some View {
         VStack(spacing: 24) {
-            Spacer()
-
-            // Large icon
             Image(systemName: "viewfinder.circle")
                 .font(.system(size: 72, weight: .thin))
                 .foregroundStyle(.secondary.opacity(0.5))
                 .padding(.bottom, 8)
 
-            // Main instruction
             VStack(spacing: 8) {
-                Text("Scan an Ingredient Label")
+                Text("Capture the Whole Ingredient Panel")
                     .font(.title2.weight(.bold))
                     .foregroundStyle(.primary)
 
-                Text("Point your camera at the ingredient list on food packaging")
+                Text("Use the live preview to frame the full ingredient list before analyzing the label.")
                     .font(.body)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -27,19 +23,19 @@ struct EmptyStateView: View {
 
             // Tips
             VStack(alignment: .leading, spacing: 16) {
-                tipRow(icon: "viewfinder", text: "Fill the frame with text")
-                tipRow(icon: "lightbulb", text: "Use good lighting")
-                tipRow(icon: "hand.tap", text: "Hold steady for auto-capture")
+                tipRow(icon: "viewfinder", text: "Fill the frame with the ingredient panel")
+                tipRow(icon: "sun.max", text: "Reduce glare from glossy packaging")
+                tipRow(icon: "arrow.up.left.and.down.right.magnifyingglass", text: "Keep curved labels as flat as possible")
             }
             .padding(.top, 8)
-
-            Spacer()
-            Spacer()
         }
         .frame(maxWidth: .infinity)
+        .padding(.top, 12)
+        .padding(.bottom, 28)
         .transition(.opacity.combined(with: .scale(scale: 0.95)))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Ready to scan. Point your camera at an ingredient label to begin.")
+        .accessibilityLabel("Ready to scan. Frame the full ingredient panel and use Analyze Label to capture it.")
+        .accessibilityIdentifier("scan-empty-state")
     }
 
     private func tipRow(icon: String, text: String) -> some View {

--- a/PungentRoots/Views/ProcessingStateView.swift
+++ b/PungentRoots/Views/ProcessingStateView.swift
@@ -2,86 +2,73 @@ import SwiftUI
 
 /// Displays processing state with stage-by-stage feedback
 struct ProcessingStateView: View {
-    @State private var currentStage: Int = 0
-
-    private let stages = [
-        (icon: "camera.fill", text: "Capturing frame..."),
-        (icon: "doc.text.magnifyingglass", text: "Analyzing text..."),
-        (icon: "list.bullet.clipboard", text: "Checking ingredients...")
-    ]
+    let phase: ScanFlowModel.Phase
 
     var body: some View {
         VStack(spacing: 20) {
-            // Current stage icon and text
             HStack(spacing: 12) {
-                ForEach(0..<stages.count, id: \.self) { index in
-                    if index == currentStage {
-                        Image(systemName: stages[index].icon)
-                            .font(.system(size: 20, weight: .medium))
-                            .foregroundStyle(Color.accentColor)
-                            .frame(width: 32, height: 32)
-                            .background(
-                                Circle()
-                                    .fill(Color.accentColor.opacity(0.15))
-                                    .scaleEffect(currentStage == index ? 1.1 : 1.0)
-                            )
-                            .animation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: currentStage)
-                            .transition(.scale.combined(with: .opacity))
-                    }
-                }
+                Image(systemName: stage.icon)
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 40, height: 40)
+                    .background(
+                        Circle()
+                            .fill(Color.accentColor.opacity(0.15))
+                    )
+                    .symbolEffect(.pulse, options: .repeating)
 
-                Text(stages[min(currentStage, stages.count - 1)].text)
+                Text(stage.text)
                     .font(.body)
                     .foregroundStyle(.primary)
-                    .animation(.easeInOut, value: currentStage)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Progress bar
             GeometryReader { geometry in
                 ZStack(alignment: .leading) {
-                    // Background track
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
                         .fill(Color.secondary.opacity(0.2))
                         .frame(height: 6)
 
-                    // Progress fill
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
                         .fill(Color.accentColor)
                         .frame(width: geometry.size.width * progress, height: 6)
-                        .animation(.easeInOut(duration: 0.3), value: currentStage)
+                        .animation(.easeInOut(duration: 0.3), value: phase)
                 }
             }
             .frame(height: 6)
         }
         .padding(20)
-        .onAppear {
-            startProgressAnimation()
-        }
+        .accessibilityIdentifier("scan-processing-state")
     }
 
     private var progress: CGFloat {
-        CGFloat(currentStage + 1) / CGFloat(stages.count)
+        switch phase {
+        case .framing:
+            return 0.05
+        case .capturing:
+            return 0.35
+        case .analyzing:
+            return 0.82
+        case .result:
+            return 1
+        }
     }
 
-    private func startProgressAnimation() {
-        // Stage 1: 0.3s
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            withAnimation {
-                currentStage = 1
-            }
-        }
-
-        // Stage 2: 0.5s after stage 1
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-            withAnimation {
-                currentStage = 2
-            }
+    private var stage: (icon: String, text: String) {
+        switch phase {
+        case .framing:
+            return ("viewfinder.circle", "Frame the entire ingredient panel before analyzing.")
+        case .capturing:
+            return ("camera.shutter.button", "Capturing a full-resolution label photo…")
+        case .analyzing:
+            return ("doc.text.magnifyingglass", "Reading the full label and checking ingredients…")
+        case .result:
+            return ("checkmark.circle", "Scan complete.")
         }
     }
 }
 
 #Preview {
-    ProcessingStateView()
+    ProcessingStateView(phase: .analyzing)
         .padding()
 }

--- a/PungentRoots/Views/ScanActionBarView.swift
+++ b/PungentRoots/Views/ScanActionBarView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct ScanActionBarView: View {
+    let flowModel: ScanFlowModel
+    let onSettings: () -> Void
+
+    var body: some View {
+        adaptiveGlassGroup(spacing: 14) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(title)
+                            .font(.headline)
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+
+                    if let badge = statusBadge {
+                        Text(badge)
+                            .font(.caption.weight(.semibold))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .adaptiveBadgeSurface(tint: badgeTint)
+                    }
+                }
+
+                HStack(spacing: 12) {
+                    if flowModel.phase == .result {
+                        Button(action: flowModel.rescan) {
+                            Label("Retake Label", systemImage: "camera.rotate")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .adaptivePrimaryButtonStyle()
+                        .controlSize(.large)
+                        .accessibilityIdentifier("retake-label-button")
+                    } else if flowModel.isProcessing {
+                        Button(action: {}) {
+                            Label(
+                                flowModel.phase == .capturing ? "Capturing…" : "Analyzing…",
+                                systemImage: flowModel.phase == .capturing ? "camera.shutter.button" : "wand.and.stars"
+                            )
+                            .frame(maxWidth: .infinity)
+                        }
+                        .disabled(true)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                    } else {
+                        Button(action: flowModel.captureLabel) {
+                            Label("Analyze Label", systemImage: "camera.metering.matrix")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .adaptivePrimaryButtonStyle()
+                        .controlSize(.large)
+                        .disabled(flowModel.canAnalyzeLabel == false)
+                        .accessibilityIdentifier("analyze-label-button")
+                    }
+
+                    Button(action: onSettings) {
+                        Image(systemName: "slider.horizontal.3")
+                            .frame(width: 44, height: 44)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("scan-settings-button")
+                }
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .adaptiveCardSurface(cornerRadius: 24)
+        }
+    }
+
+    private var title: String {
+        switch flowModel.phase {
+        case .framing:
+            return "Frame the full ingredient list"
+        case .capturing:
+            return "Capturing the full label"
+        case .analyzing:
+            return "Reading the captured label"
+        case .result:
+            return "Review the full-label scan"
+        }
+    }
+
+    private var subtitle: String {
+        switch flowModel.phase {
+        case .framing:
+            return "Center the ingredient panel, reduce glare, and keep the package as flat as possible."
+        case .capturing:
+            return "Hold steady while the app saves a high-quality still image for OCR."
+        case .analyzing:
+            return "The app is reading the full photo, including small or off-center packaging text."
+        case .result:
+            return flowModel.analysis?.coverageStatus.subtitle ?? "Review the detected terms and transcript before deciding."
+        }
+    }
+
+    private var statusBadge: String? {
+        guard flowModel.phase == .result else { return nil }
+        return flowModel.analysis?.coverageStatus.title
+    }
+
+    private var badgeTint: Color {
+        switch flowModel.analysis?.coverageStatus {
+        case .complete:
+            return .green
+        case .partial:
+            return .orange
+        case .insufficient:
+            return .red
+        case nil:
+            return .secondary
+        }
+    }
+}

--- a/PungentRoots/Views/ScanCameraModuleView.swift
+++ b/PungentRoots/Views/ScanCameraModuleView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct ScanCameraModuleView: View {
+    let flowModel: ScanFlowModel
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .title2) private var baseCameraHeight: CGFloat = 340
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(.thickMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 28, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.12), radius: 18, x: 0, y: 12)
+
+                GeometryReader { proxy in
+                    previewContent(size: proxy.size)
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                        .accessibilityElement(children: .contain)
+                }
+                .padding(6)
+            }
+            .frame(height: cameraHeight)
+            .frame(maxWidth: .infinity)
+            .overlay(statusBadgeOverlay, alignment: .topLeading)
+            .overlay(alignment: .center) {
+                if case .error = flowModel.captureState {
+                    errorOverlay
+                }
+            }
+            .padding(.horizontal, -16)
+            .accessibilityIdentifier("scan-camera-module")
+        }
+    }
+
+    private var cameraHeight: CGFloat {
+        let minimum: CGFloat = dynamicTypeSize.isAccessibilitySize ? 380 : 320
+        return max(minimum, baseCameraHeight)
+    }
+
+    @ViewBuilder
+    private func previewContent(size: CGSize) -> some View {
+#if os(iOS)
+        if let controller = flowModel.captureController {
+            LabelCameraPreview(controller: controller)
+                .overlay(alignmentGuides)
+                .overlay(alignment: .bottomLeading) {
+                    framingHints
+                }
+        } else {
+            previewFallback
+        }
+#else
+        previewFallback
+#endif
+    }
+
+    private var previewFallback: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "camera.viewfinder")
+                .font(.system(size: 42, weight: .regular))
+                .foregroundStyle(.secondary)
+            Text("Camera preview is unavailable in this mode.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(0.45))
+    }
+
+    private var alignmentGuides: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12), style: StrokeStyle(lineWidth: 1, dash: [8, 10]))
+                .padding(28)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var framingHints: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            tipPill(icon: "viewfinder", text: "Fill the frame with the ingredient panel")
+            tipPill(icon: "sun.max", text: "Reduce glare from shiny packaging")
+            tipPill(icon: "arrow.up.left.and.down.right.magnifyingglass", text: "Keep curved labels as flat as possible")
+        }
+        .padding(16)
+    }
+
+    private func tipPill(icon: String, text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+            Text(text)
+                .lineLimit(2)
+        }
+        .font(.caption.weight(.semibold))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .adaptiveBadgeSurface(tint: .white)
+    }
+
+    private var statusBadgeOverlay: some View {
+        HStack {
+            adaptiveGlassGroup(spacing: 12) {
+                statusBadge
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+    }
+
+    private var statusBadge: some View {
+        let descriptor = statusDescriptor
+        let stateColor = descriptor.color
+
+        return HStack(spacing: 8) {
+            if flowModel.captureState == .scanning || flowModel.isProcessing {
+                Circle()
+                    .fill(stateColor)
+                    .frame(width: 6, height: 6)
+                    .overlay(
+                        Circle()
+                            .fill(stateColor.opacity(0.3))
+                            .scaleEffect(1.8)
+                    )
+                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: flowModel.captureState)
+            }
+
+            Label(descriptor.text, systemImage: descriptor.icon)
+                .font(.footnote.weight(.semibold))
+                .symbolEffect(.pulse, options: .repeating, value: flowModel.isProcessing)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .foregroundStyle(.white)
+        .adaptiveBadgeSurface(tint: stateColor)
+        .shadow(color: stateColor.opacity(0.3), radius: 8, x: 0, y: 2)
+        .accessibilityHint(Text("scan.status.accessibility.hint"))
+        .accessibilityIdentifier("scan-status-badge")
+    }
+
+    private var statusDescriptor: (text: LocalizedStringKey, icon: String, color: Color) {
+        switch flowModel.phase {
+        case .capturing:
+            return (LocalizedStringKey("scan.status.default_capturing"), "camera.shutter.button", .orange)
+        case .analyzing:
+            return (LocalizedStringKey("scan.status.default_processing"), "wand.and.stars", .orange)
+        case .framing:
+            switch flowModel.captureReadiness {
+            case .none:
+                return (LocalizedStringKey("scan.status.default_scanning"), "camera.viewfinder", .blue)
+            case .tooFar:
+                return (LocalizedStringKey("scan.status.move_closer"), "arrow.down.forward.and.arrow.up.backward", .orange)
+            case .almostReady:
+                return (LocalizedStringKey("scan.status.almost_ready"), "camera.metering.center.weighted", .yellow)
+            case .ready:
+                return (LocalizedStringKey("scan.status.ready"), "checkmark.circle", .green)
+            }
+        case .result:
+            let descriptor = flowModel.captureState.descriptor
+            return (descriptor.text, descriptor.icon, statusColor(for: flowModel.captureState))
+        }
+    }
+
+    private func statusColor(for state: CaptureState) -> Color {
+        switch state {
+        case .idle, .preparing:
+            return .gray
+        case .scanning:
+            return .blue
+        case .processing:
+            return .orange
+        case .paused:
+            return .green
+        case .error:
+            return .red
+        }
+    }
+
+    private var errorOverlay: some View {
+        VStack(spacing: 12) {
+            Label("scan.error.title", systemImage: "exclamationmark.triangle.fill")
+                .font(.footnote.weight(.semibold))
+            Button(action: flowModel.rescan) {
+                Label("scan.error.retry", systemImage: "arrow.clockwise")
+            }
+            .adaptivePrimaryButtonStyle()
+        }
+        .padding(24)
+        .adaptiveCardSurface(cornerRadius: 20)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/PungentRoots/Views/ScanResultSectionView.swift
+++ b/PungentRoots/Views/ScanResultSectionView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+struct ScanResultSectionView: View {
+    let flowModel: ScanFlowModel
+
+    var body: some View {
+        Group {
+            if flowModel.isProcessing {
+                contentCard {
+                    ProcessingStateView(phase: flowModel.phase)
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else if let analysis = flowModel.analysis, flowModel.normalizedText.isEmpty == false {
+                contentCard {
+                    detectionResultView(analysis: analysis)
+                }
+                .transition(.asymmetric(
+                    insertion: .move(edge: .bottom).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+            }
+        }
+        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: flowModel.isProcessing)
+        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: flowModel.analysis?.verdict)
+    }
+
+    private func contentCard<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .adaptiveCardSurface(cornerRadius: 24)
+    }
+
+    private func detectionResultView(analysis: ScanAnalysis) -> some View {
+        DetectionResultView(
+            analysis: analysis,
+            capturedImage: capturedImage,
+            detectionBoxes: flowModel.highlightedBoxes,
+            isShowingFullText: Binding(
+                get: { flowModel.isShowingFullText },
+                set: { flowModel.isShowingFullText = $0 }
+            )
+        )
+    }
+
+#if os(iOS)
+    private var capturedImage: UIImage? {
+        flowModel.analysis?.capturedImageData.flatMap(UIImage.init(data:))
+    }
+#else
+    private var capturedImage: UIImage? { nil }
+#endif
+}

--- a/PungentRoots/Views/SettingsView.swift
+++ b/PungentRoots/Views/SettingsView.swift
@@ -4,69 +4,44 @@ struct SettingsView: View {
     @Environment(AppEnvironment.self) private var appEnvironment
     @State private var showingCaptureTips = false
 
-#if os(iOS)
-    @MainActor
-    private var dataScannerSupported: Bool {
-        if #available(iOS 16.0, *) {
-            return DataScannerCaptureController.isSupported
-        } else {
-            return false
-        }
-    }
-#else
-    private var dataScannerSupported: Bool { false }
-#endif
-
     var body: some View {
-        @Bindable var bindings = appEnvironment
-
         ScrollView {
             VStack(spacing: 20) {
-                // App header
-                VStack(spacing: 12) {
-                    Image(systemName: "camera.macro.circle.fill")
-                        .font(.system(size: 56))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [Color.accentColor, Color.accentColor.opacity(0.7)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
+                adaptiveGlassGroup(spacing: 18) {
+                    VStack(spacing: 12) {
+                        Image(systemName: "camera.macro.circle.fill")
+                            .font(.system(size: 56))
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [Color.accentColor, Color.accentColor.opacity(0.7)],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
                             )
-                        )
-                        .padding(.top, 8)
+                            .padding(.top, 8)
+                            .padding(12)
+                            .adaptiveBadgeSurface(tint: .accentColor)
 
-                    Text("Pungent Roots")
-                        .font(.title2.weight(.bold))
+                        Text("Pungent Roots")
+                            .font(.title2.weight(.bold))
 
-                    Text("settings.header.tagline")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+                        Text("settings.header.tagline")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
                 }
-                .padding(.vertical, 8)
 
                 // Capture settings card
                 settingsCard(title: LocalizedStringKey("settings.capture.heading"), icon: "camera.viewfinder") {
                     VStack(alignment: .leading, spacing: 16) {
-                        Toggle(isOn: $bindings.captureOptions.prefersDataScanner) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("settings.visionkit.toggle")
-                                    .font(.subheadline.weight(.medium))
-                                Text("settings.visionkit.description")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .toggleStyle(.switch)
-                        .disabled(!dataScannerSupported)
-
-#if os(iOS)
-                        if !dataScannerSupported {
-                            Text("settings.visionkit.unsupported")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                        }
-#endif
+                        infoRow(
+                            icon: "camera.aperture",
+                            title: LocalizedStringKey("settings.capture.full_label.title"),
+                            description: LocalizedStringKey("settings.capture.full_label.description")
+                        )
 
                         Button {
                             showingCaptureTips.toggle()
@@ -90,6 +65,21 @@ struct SettingsView: View {
                             .padding(.top, 4)
                             .transition(.opacity.combined(with: .move(edge: .top)))
                         }
+                    }
+                }
+
+                settingsCard(title: LocalizedStringKey("settings.quality.heading"), icon: "checkmark.seal.text.page.fill") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        infoRow(
+                            icon: "checkmark.seal.fill",
+                            title: LocalizedStringKey("settings.quality.complete.title"),
+                            description: LocalizedStringKey("settings.quality.complete.description")
+                        )
+                        infoRow(
+                            icon: "exclamationmark.triangle.fill",
+                            title: LocalizedStringKey("settings.quality.partial.title"),
+                            description: LocalizedStringKey("settings.quality.partial.description")
+                        )
                     }
                 }
 
@@ -152,6 +142,11 @@ struct SettingsView: View {
                             title: LocalizedStringKey("settings.support.fresh.title"),
                             description: LocalizedStringKey("settings.support.fresh.description")
                         )
+                        infoRow(
+                            icon: "camera.filters",
+                            title: LocalizedStringKey("settings.support.packaging.title"),
+                            description: LocalizedStringKey("settings.support.packaging.description")
+                        )
                     }
                 }
             }
@@ -172,10 +167,7 @@ struct SettingsView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(.secondarySystemBackground))
-        )
+        .adaptiveCardSurface(cornerRadius: 16)
     }
 
     private func tipRow(icon: String, text: LocalizedStringKey) -> some View {

--- a/PungentRootsTests/PungentRootsTests.swift
+++ b/PungentRootsTests/PungentRootsTests.swift
@@ -92,8 +92,68 @@ struct DetectionEngineTests {
         let syncResult = environment.analyze(sample)
         let asyncResult = await environment.analyzeAsync(sample)
 
-        #expect(asyncResult.normalized == syncResult.normalized)
+        #expect(asyncResult.normalizedText == syncResult.normalizedText)
         #expect(asyncResult.result.matches == syncResult.result.matches)
         #expect(asyncResult.result.verdict == syncResult.result.verdict)
+        #expect(asyncResult.coverageStatus == .complete)
+    }
+
+    @Test("Footer-only packaging text requires review")
+    @MainActor
+    func footerOnlyTextRequiresReview() {
+        let environment = AppEnvironment(dictionary: dictionary)
+        let label = CapturedLabel(
+            imageData: nil,
+            recognizedBlocks: [
+                RecognizedTextBlock(
+                    text: "Contains Sesame. Dist & sold exclusively by Trader Joe's",
+                    boundingBox: CGRect(x: 0.1, y: 0.5, width: 0.8, height: 0.12),
+                    confidence: 0.94
+                )
+            ],
+            rawText: "Contains Sesame. Dist & sold exclusively by Trader Joe's",
+            coverageStatus: .insufficient,
+            warnings: PackagingTextAnalyzer.warnings(
+                for: .insufficient,
+                rawText: "Contains Sesame. Dist & sold exclusively by Trader Joe's"
+            )
+        )
+
+        let analysis = environment.analyzeCapturedLabel(label)
+
+        #expect(analysis.result.verdict == .needsReview)
+        #expect(analysis.coverageStatus == .insufficient)
+        #expect(analysis.warnings.isEmpty == false)
+    }
+
+    @Test("Packaging text merge removes duplicated OCR blocks")
+    func packagingMergeDeduplicatesRepeatedBlocks() {
+        let blocks = [
+            RecognizedTextBlock(text: "Ingredients", boundingBox: CGRect(x: 0.1, y: 0.8, width: 0.3, height: 0.06), confidence: 0.82),
+            RecognizedTextBlock(text: "Ingredients", boundingBox: CGRect(x: 0.11, y: 0.79, width: 0.3, height: 0.06), confidence: 0.93),
+            RecognizedTextBlock(text: "Onion Powder", boundingBox: CGRect(x: 0.1, y: 0.7, width: 0.4, height: 0.08), confidence: 0.9)
+        ]
+
+        let merged = PackagingTextAnalyzer.mergeBlocks(blocks)
+
+        #expect(merged.count == 2)
+        #expect(merged.first?.confidence == 0.93)
+    }
+
+    @Test("Coverage classification prefers complete ingredient panels")
+    func coverageClassifierPrefersIngredientPanels() {
+        let blocks = [
+            RecognizedTextBlock(text: "Ingredients", boundingBox: CGRect(x: 0.1, y: 0.82, width: 0.28, height: 0.06), confidence: 0.94),
+            RecognizedTextBlock(text: "Potatoes, sunflower oil, onion powder, garlic powder, sea salt", boundingBox: CGRect(x: 0.08, y: 0.62, width: 0.84, height: 0.18), confidence: 0.92),
+            RecognizedTextBlock(text: "Paprika, yeast extract, spices", boundingBox: CGRect(x: 0.08, y: 0.46, width: 0.78, height: 0.12), confidence: 0.88),
+            RecognizedTextBlock(text: "Distributed by Trader Joe's", boundingBox: CGRect(x: 0.1, y: 0.14, width: 0.52, height: 0.06), confidence: 0.9)
+        ]
+
+        let status = PackagingTextAnalyzer.coverageStatus(
+            for: blocks,
+            rawText: blocks.map(\.text).joined(separator: "\n")
+        )
+
+        #expect(status == .complete)
     }
 }

--- a/PungentRootsTests/ScanFlowModelTests.swift
+++ b/PungentRootsTests/ScanFlowModelTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import PungentRoots
+
+@MainActor
+struct ScanFlowModelTests {
+    @Test("Scan analysis keeps raw and normalized text")
+    func scanAnalysisTracksSourceAndNormalization() {
+        let environment = AppEnvironment.preview
+        let analysis = environment.analyze("Ingredients: Onio-\nn Powder")
+
+        #expect(analysis.rawText.contains("Onio-"))
+        #expect(analysis.normalizedText.contains("onion powder"))
+        #expect(analysis.verdict == .contains)
+    }
+
+    @Test("UI test preview loads a deterministic result")
+    func previewLaunchLoadsResultWithoutCapture() {
+        let flowModel = ScanFlowModel(
+            launchArguments: ["--ui-test-disable-capture", "--ui-test-preview-result"]
+        )
+
+        flowModel.bind(environment: .preview)
+
+        #expect(flowModel.detectionResult != nil)
+        #expect(flowModel.captureState == .paused)
+        #expect(flowModel.captureReadiness == .ready)
+        #expect(flowModel.isProcessing == false)
+        #expect(flowModel.phase == .result)
+    }
+
+    @Test("Rescan clears preview analysis and returns to scanning")
+    func rescanClearsPreviewAnalysis() {
+        let flowModel = ScanFlowModel(
+            launchArguments: ["--ui-test-disable-capture", "--ui-test-preview-result"]
+        )
+
+        flowModel.bind(environment: .preview)
+        flowModel.rescan()
+
+        #expect(flowModel.detectionResult == nil)
+        #expect(flowModel.captureState == .scanning)
+        #expect(flowModel.showsEmptyState)
+        #expect(flowModel.phase == .framing)
+    }
+
+    @Test("Partial preview requires review when ingredient coverage is missing")
+    func partialPreviewRequiresReview() {
+        let flowModel = ScanFlowModel(
+            launchArguments: ["--ui-test-disable-capture", "--ui-test-preview-partial-result"]
+        )
+
+        flowModel.bind(environment: .preview)
+
+        #expect(flowModel.phase == .result)
+        #expect(flowModel.analysis?.coverageStatus == .insufficient)
+        #expect(flowModel.analysis?.verdict == .needsReview)
+        #expect(flowModel.analysis?.warnings.isEmpty == false)
+    }
+
+    @Test("Overlay mapping keeps the highest severity per detected term")
+    func overlayMappingUsesHighestSeverity() {
+        let items = [
+            RecognizedTextBlock(text: "Onion Powder", boundingBox: CGRect(x: 0.2, y: 0.2, width: 0.3, height: 0.1), confidence: 0.91),
+            RecognizedTextBlock(text: "Sea Salt", boundingBox: CGRect(x: 0.2, y: 0.4, width: 0.2, height: 0.1), confidence: 0.89)
+        ]
+        let matches = [
+            Match(term: "onion", kind: .ambiguous, range: 0..<5, note: "ambiguous"),
+            Match(term: "onion", kind: .definite, range: 0..<5, note: "definite")
+        ]
+
+        let overlays = DetectionOverlay.overlays(for: items, matches: matches)
+
+        #expect(overlays.count == 1)
+        #expect(overlays.first?.severity == .high)
+    }
+}

--- a/PungentRootsUITests/PungentRootsUITests.swift
+++ b/PungentRootsUITests/PungentRootsUITests.swift
@@ -8,55 +8,82 @@
 import XCTest
 
 final class PungentRootsUITests: XCTestCase {
+    private func launchApp(arguments: [String] = []) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments.append(contentsOf: arguments)
+        app.launch()
+        return app
+    }
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
     @MainActor
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            let app = XCUIApplication()
+            app.launchArguments.append("--ui-test-disable-capture")
+            app.launch()
         }
     }
 
     @MainActor
     func testSettingsSupportsDynamicType() throws {
-        let app = XCUIApplication()
-        app.launchArguments.append(contentsOf: ["-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibility3"])
-        app.launch()
-
-        app.buttons["Info"].tap()
+        let app = launchApp(
+            arguments: [
+                "--ui-test-disable-capture",
+                "--ui-test-open-settings",
+                "-UIPreferredContentSizeCategoryName",
+                "UICTContentSizeCategoryAccessibility3"
+            ]
+        )
 
         let navBar = app.navigationBars["Info & Settings"]
         XCTAssertTrue(navBar.waitForExistence(timeout: 3))
 
-        let toggle = app.switches.firstMatch
-        XCTAssertTrue(toggle.waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Scan Quality"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Full-label still capture"].exists)
 
         let screenshot = XCUIScreen.main.screenshot()
         let attachment = XCTAttachment(screenshot: screenshot)
         attachment.name = "Settings-DynamicType-AX3"
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    @MainActor
+    func testPreviewResultSupportsTranscriptDisclosure() throws {
+        let app = launchApp(arguments: ["--ui-test-disable-capture", "--ui-test-preview-result"])
+
+        let toggle = app.buttons["toggle-scanned-text"]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 3))
+        toggle.tap()
+
+        XCTAssertTrue(app.staticTexts["Hide scanned text"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "onion powder")).firstMatch.exists)
+    }
+
+    @MainActor
+    func testRetakeReturnsToFramingState() throws {
+        let app = launchApp(arguments: ["--ui-test-disable-capture", "--ui-test-preview-result"])
+
+        let retakeButton = app.buttons["retake-label-button"]
+        XCTAssertTrue(retakeButton.waitForExistence(timeout: 3))
+        retakeButton.tap()
+
+        XCTAssertTrue(app.buttons["analyze-label-button"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["toggle-scanned-text"].exists)
+        XCTAssertTrue(app.staticTexts["Capture the Whole Ingredient Panel"].waitForExistence(timeout: 2))
+    }
+
+    @MainActor
+    func testPartialResultShowsIncompleteWarning() throws {
+        let app = launchApp(arguments: ["--ui-test-disable-capture", "--ui-test-preview-partial-result"])
+
+        XCTAssertTrue(app.staticTexts["Only partial packaging text was read"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts.containing(NSPredicate(format: "label CONTAINS[c] %@", "Retake the photo")).firstMatch.exists)
+        XCTAssertTrue(app.buttons["retake-label-button"].exists)
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
 # PungentRoots
 
 ## Developer Summary
-PungentRoots is a SwiftUI iOS app that screens ingredient labels for allium-containing terms entirely on-device. Live capture defaults to VisionKit’s `DataScannerViewController` for low-latency text extraction, falling back to the legacy `AVCaptureSession` + Vision OCR pipeline when hardware support is unavailable. A rule-based detection engine scores risk levels and surfaces accessibility-friendly verdicts to the UI. The codebase is organized by feature (camera/OCR, detection, services, views) so each module can evolve independently while sharing normalization utilities.
+PungentRoots is a SwiftUI iOS app that screens ingredient labels for pungent-root ingredients entirely on-device. The app targets `iOS 18.5+`, prefers VisionKit’s `DataScannerViewController` on supported hardware, and falls back to a legacy `AVCaptureSession` + Vision OCR path when needed. Detection stays rule-based and local, while the UI uses a typed scan flow model and availability-gated iOS 26 styling improvements rather than platform-specific forks.
 
-## Architecture at a Glance
-1. **App bootstrap** – `PungentRootsApp` loads the bundled dictionary and injects shared services through `AppEnvironment`.
-2. **Capture + OCR** – `AutoCaptureController` negotiates between VisionKit `DataScannerViewController` and the legacy `LiveCaptureController` (AVFoundation + Vision) while `TextAcquisitionService` and `OCRConfiguration` normalize text for detection. Camera UI now uses system materials, Dynamic Type-aware sizing, and localized guidance.
-3. **Detection Engine** – `DetectionEngine` consults `DetectDictionary` to run exact, synonym, pattern, ambiguous, and fuzzy passes that yield `DetectionResult` aggregates. Async helpers in `AppEnvironment` execute scoring off the main thread with signpost instrumentation.
-4. **Models & Persistence** – Types in `Models/` (`Scan`, `Match`, enums) mirror detection payloads and keep highlight ranges consistent for SwiftUI overlays.
-5. **Presentation** – SwiftUI views under `Views/` render camera overlays, result cards, settings, and guidance affordances while respecting environment services. Shared strings live in `Resources/en.lproj/Localizable.strings` for future localization.
-6. **Observability** – `MetricReporter` subscribes to `MXMetricManager` and `OSSignposter` intervals capture detection latency for performance regression tracking.
+## Architecture At a Glance
+1. **App bootstrap**: `PungentRootsApp` creates the live `AppEnvironment` and injects it into the root scene.
+2. **Screen orchestration**: `ContentView` remains a thin shell. `ScanFlowModel` owns capture lifecycle, async analysis, cancellation, error presentation, transcript disclosure state, and rescan behavior.
+3. **Capture pipeline**: `AutoCaptureController` selects between the VisionKit scanner and the legacy `LiveCaptureController`. Both paths publish shared `CapturePayload`, `CaptureState`, and `CaptureReadiness` values so the UI does not depend on legacy controller details.
+4. **OCR + detection**: `TextAcquisitionService` normalizes captured text and `AppEnvironment` returns a typed `ScanAnalysis` from sync and async analysis entrypoints.
+5. **Presentation**: `ScanCameraModuleView`, `ScanResultSectionView`, `DetectionResultView`, and supporting views keep the UI modular and Dynamic Type-friendly. `AdaptiveGlass.swift` applies Liquid Glass selectively on iOS 26 and falls back to material styling below that.
+6. **Observability**: `MetricReporter` subscribes to MetricKit and detection work remains instrumented for performance tracking.
 
 ## Local Development
-- Open `PungentRoots.xcodeproj` in Xcode 15+ (iOS 17+ SDK recommended) or run `xed .`.
-- Preferred build: `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro" build`.
-- Preferred full test pass: `Scripts/run-tests.sh` (wraps `xcodebuild test` and simulator shutdown for reproducibility).
-- Dictionary source lives at `PungentRoots/Resources/pungent_roots_dictionary.json`; keep entries sorted, localized groupings intact, and bump the embedded `version` field when editing.
+- Open `PungentRoots.xcodeproj` in Xcode or run `xed .`.
+- Preferred build:
+  - `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" build`
+- Preferred full test pass:
+  - `Scripts/run-tests.sh`
+- Useful UI-test launch arguments:
+  - `--ui-test-disable-capture`
+  - `--ui-test-preview-result`
+- Dictionary source lives at `PungentRoots/Resources/pungent_roots_dictionary.json`; keep entries sorted and bump the embedded `version` field when editing it.
 
 ## Contribution Notes
-- Detection assumes normalized UTF-16 ranges—when adjusting tokenizers or matchers, preserve range math to keep highlights accurate.
-- Camera and OCR work run off the main actor; funnel UI mutations back through `DispatchQueue.main`/`@MainActor` to avoid state races. Use `AppEnvironment.analyzeAsync` for long-running analysis.
-- When expanding verdicts or UI states, update `DetectionResultView` (and related overlays) plus add coverage under `PungentRootsTests/` or document manual validation for camera heuristics.
+- Keep `ContentView` thin and move new screen orchestration into `ScanFlowModel`.
+- Use `ScanAnalysis` for result plumbing instead of ad hoc tuples.
+- Keep shared UI state on `CapturePayload`, `CaptureState`, and `CaptureReadiness` rather than leaking `LiveCaptureController` internals upward.
+- Treat iOS 26 UI APIs as additive. All Liquid Glass usage must have lower-version fallbacks.
+- When changing capture behavior, verify both supported Data Scanner devices and the forced-legacy path.
+- When changing detection or normalization, add or update `Testing`-framework coverage and preserve normalized UTF-16 range behavior for highlights.
+
+## Documentation Ownership
+- `AGENTS.md` is the canonical repo guide for coding agents.
+- `CLAUDE.md` and `GEMINI.md` are intentionally thin wrappers.
+- `PLAN.md` holds the manual validation matrix for capture, permissions, and platform fallback checks.
 
 ## License
 PungentRoots is distributed under the terms of the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- refresh the app around a packaging-first scan flow with explicit full-label capture and result states
- replace the production Data Scanner path with a hardened AVFoundation still-photo pipeline
- improve OCR analysis, scan-quality handling, and suspect-text overlays for food packaging
- consolidate the repo agent guidance around `AGENTS.md`

## What Changed
- added `ScanFlowModel`, `ScanAnalysis`, `CapturedLabel`, and shared capture-domain types to separate UI flow from camera internals
- introduced `LabelCaptureController` with `AVCapturePhotoOutput`, session interruption/runtime recovery, and safe post-configuration session startup
- refreshed the main SwiftUI experience for iOS 26 with restrained Liquid Glass on compact chrome and clearer framing/analyzing/result states
- updated packaging OCR to use a single high-quality full-image pass and stricter overlay matching so transcripts are not repeated and suspect boxes only attach to real recognized text
- expanded unit/UI coverage for scan flow, scan-quality classification, transcript disclosure, retake flow, and settings accessibility sizing
- rewrote `AGENTS.md` as the canonical repo guide and reduced `CLAUDE.md` / `GEMINI.md` to thin wrappers

## Root Cause Notes
- fixed a capture-session lifecycle bug where `AVCaptureSession.startRunning()` could be reached while a configuration block was still open, which caused the on-device `NSGenericException` crash
- removed the production dependency on point-of-interest live OCR so partial footer text no longer drives final ingredient verdicts

## Validation
- `xcodebuild -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" build`
- `Scripts/run-tests.sh`
- `xcodebuild test -scheme PungentRoots -destination "platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro" -only-testing:PungentRootsTests -only-testing:PungentRootsUITests/testPreviewResultSupportsTranscriptDisclosure -only-testing:PungentRootsTests/ScanFlowModelTests/overlayMappingUsesHighestSeverity`

## Notes
- `Scripts/run-tests.sh` completes successfully, though Xcode still emits a post-success cloned-simulator `xctrunner` cleanup error after `** TEST SUCCEEDED **`; the suite itself passes.
- local Xcode breakpoint data was intentionally left out of this PR.